### PR TITLE
Fix for issue with string input

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -27,7 +27,7 @@ function Parser(fileContents, defaultCharset){
 
     if(typeof fileContents == "string"){
         this._charset = "utf-8";
-        this._file = fileContents;
+        this._fileContents = fileContents;
     }else{
         this._handleCharset(fileContents);
     }

--- a/test/po-parser.js
+++ b/test/po-parser.js
@@ -15,6 +15,20 @@ module.exports["UTF-8"] = {
     }
 }
 
+module.exports["UTF-8 as string"] = {
+    setUp: function(callback){
+        this.po = fs.readFileSync(__dirname + "/fixtures/utf8.po", 'utf-8');
+        this.json = JSON.parse(fs.readFileSync(__dirname + "/fixtures/utf8-po.json", "utf-8"));
+        callback();
+    },
+
+    parse: function(test){
+        var parsed = gettextParser.po.parse(this.po);
+        test.deepEqual(parsed, this.json);
+        test.done();
+    }
+}
+
 module.exports["Latin-13"] = {
     setUp: function(callback){
         this.po = fs.readFileSync(__dirname + "/fixtures/latin13.po");


### PR DESCRIPTION
There was an issue when po data was passed as a string instead of bugger to `poparser` - the po data was set to `this._file` which was never used later - `_lexer` was looking for data in `this._fileContents`. This resulted in an error being thrown.

The current PR fixes this issue.
