### PR TITLE
Fix double quotes are being escaped unnecessarily

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -143,7 +143,7 @@ Parser.prototype._lexer = function(){
                         case "n": node.value += "\n"; break;
                         case "r": node.value += "\r"; break;
                         default:
-                            node.value += "\\" + chr;
+                            node.value += chr;
                     }
                     escaped = false;
                 }else{

--- a/test/fixtures/utf8-po.json
+++ b/test/fixtures/utf8-po.json
@@ -68,6 +68,15 @@
                 "msgstr": [
                     "test"
                 ]
+            },
+            "\"\\'\t": {
+                "msgid": "\"\\'\t",
+                "comments": {
+                    "translator": "String with escapes"
+                },
+                "msgstr": [
+                    "\"\\'\t"
+                ]
             }
         },
         "c1": {

--- a/test/fixtures/utf8.po
+++ b/test/fixtures/utf8.po
@@ -50,6 +50,10 @@ msgstr "t3-žš"
 msgid "test"
 msgstr "test"
 
+# String with escapes
+msgid "\"\\'\t"
+msgstr "\"\\'\t"
+
 # Normal string in a context
 msgctxt "c1"
 msgid "co1"

--- a/test/po-compiler.js
+++ b/test/po-compiler.js
@@ -14,7 +14,7 @@ module.exports["UTF-8"] = {
     }
 }
 
-module.exports["Latin-8"] = {
+module.exports["Latin13"] = {
     setUp: function(callback){
         this.json = JSON.parse(fs.readFileSync(__dirname + "/fixtures/latin13-po.json", "utf-8"));
         this.po = fs.readFileSync(__dirname + "/fixtures/latin13.po");

--- a/test/po-parser.js
+++ b/test/po-parser.js
@@ -29,7 +29,7 @@ module.exports["UTF-8 as string"] = {
     }
 }
 
-module.exports["Latin-13"] = {
+module.exports["Latin13"] = {
     setUp: function(callback){
         this.po = fs.readFileSync(__dirname + "/fixtures/latin13.po");
         this.json = JSON.parse(fs.readFileSync(__dirname + "/fixtures/latin13-po.json", "utf-8"));


### PR DESCRIPTION
Double quotes were escaped when reading PO files which was not the
correct behavior. This patch fixes that and also simply outputs the
escape char when it is unknown.
