### PR TITLE
lib: remove unreachable code

### DIFF
--- a/lib/pocompiler.js
+++ b/lib/pocompiler.js
@@ -117,8 +117,6 @@ Compiler.prototype._drawBlock = function(block, override) {
  * @return {String} Joined and escaped key-value pair
  */
 Compiler.prototype._addPOString = function(key, value) {
-    var line;
-
     key = (key || '').toString();
 
     // escape newlines and quotes
@@ -136,17 +134,6 @@ Compiler.prototype._addPOString = function(key, value) {
     } else {
         return key + ' ""\n"' + lines.join('"\n"') + '"';
     }
-
-    if (value.match(/\n/)) {
-        value = value.replace(/\n/g, '\\n\n').replace(/\n$/, '');
-        line = ('\n' + value).split('\n').map(function(l) {
-            return '"' + l + '"';
-        }).join('\n');
-    } else {
-        line = '"' + value + '"';
-    }
-
-    return key + ' ' + line;
 };
 
 /**


### PR DESCRIPTION
I've accidentally ran a coverity scan over this library (since it was in node_modules dir) and coverity detected dead code in pocompiler.js 