### PR TITLE
Sorting of entries with the same msgid isn't consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Where
   * **data** is a translation object either got from parsing a PO/MO file or composed by other means
   * **options** is a configuration object with possible values
     * **foldLength** is the length at which to fold message strings into newlines (default: 76). Set to 0 or false to disable folding.
-    * **sortByMsgid** (boolean) - entries will be sorted by msgid in the resulting .po(.pot) file.
+    * **sort** (boolean|Function) - (default `false`) if `true`, entries will be sorted by msgid in the resulting .po(.pot) file.
+      If a comparator function is provided, that function will be used to sort entries in the output. The function is called with two arguments, each of which is a single message entry with the structure described below. The function should follow the standard rules for functions passed to `Array.sort()`: return `0` if the entries are interchangeable in sort order; return a number less than 0 if the first entry should come before the second one; and return a number greater than 0 if the second entry should come before the first one.
 
 **Example**
 

--- a/lib/pocompiler.js
+++ b/lib/pocompiler.js
@@ -5,7 +5,8 @@ var encoding = require('encoding');
 var sharedFuncs = require('./shared');
 
 /**
- * Comparator function for comparing msgid
+ * Comparator function for comparing message entries.
+ * Entries are sorted by msgid then msgctxt.
  * @param {Object} object with msgid prev
  * @param {Object} object with msgid next
  * @returns {number} comparator index
@@ -15,6 +16,12 @@ function compare (r1, r2) {
     return 1;
   }
   if (r2.msgid > r1.msgid) {
+    return -1;
+  }
+  if (r1.msgctxt > r2.msgctxt) {
+    return 1;
+  }
+  if (r2.msgctxt > r1.msgctxt) {
     return -1;
   }
   return 0;

--- a/lib/pocompiler.js
+++ b/lib/pocompiler.js
@@ -5,8 +5,7 @@ var encoding = require('encoding');
 var sharedFuncs = require('./shared');
 
 /**
- * Comparator function for comparing message entries.
- * Entries are sorted by msgid then msgctxt.
+ * Comparator function for comparing msgid
  * @param {Object} object with msgid prev
  * @param {Object} object with msgid next
  * @returns {number} comparator index
@@ -16,12 +15,6 @@ function compare (r1, r2) {
     return 1;
   }
   if (r2.msgid > r1.msgid) {
-    return -1;
-  }
-  if (r1.msgctxt > r2.msgctxt) {
-    return 1;
-  }
-  if (r2.msgctxt > r1.msgctxt) {
     return -1;
   }
   return 0;
@@ -52,8 +45,8 @@ function Compiler (table, options) {
   if (!('foldLength' in this._options)) {
     this._options.foldLength = 76;
   }
-  if (!('sortByMsgid' in this._options)) {
-    this._options.sortByMsgid = false;
+  if (!('sort' in this._options)) {
+    this._options.sort = false;
   }
   this._translations = [];
   this._handleCharset();
@@ -228,8 +221,12 @@ Compiler.prototype.compile = function () {
     }.bind(this));
   }.bind(this));
 
-  if (this._options.sortByMsgid) {
-    response = response.sort(compare);
+  if (this._options.sort !== false) {
+    if (typeof this._options.sort === 'function') {
+      response = response.sort(this._options.sort);
+    } else {
+      response = response.sort(compare);
+    }
   }
   response = response.map(function (r) {
     return this._drawBlock(r);

--- a/test/fixtures/sort-with-msgctxt-test-1.json
+++ b/test/fixtures/sort-with-msgctxt-test-1.json
@@ -1,0 +1,36 @@
+{
+    "charset": "utf-8",
+    "headers": {
+    },
+    "translations": {
+        "": {
+            "": {
+                "msgid": "",
+                "msgstr": [""],
+                "msgctxt": ""
+            },
+            "bbbb": {
+                "msgid": "bbbb",
+                "msgstr": [ "bbbb"],
+                "msgctxt": ""
+            },
+            "aaaa": {
+                "msgid": "aaaa",
+                "msgstr": [ "aaaa"],
+                "msgctxt": ""
+            },
+            "cccc": {
+                "msgid": "cccc",
+                "msgstr": [ "cccc"],
+                "msgctxt": ""
+            }
+        },
+        "ctxt1": {
+            "aaaa": {
+                "msgid": "aaaa",
+                "msgstr": [ "aaaa"],
+                "msgctxt": "ctxt1"
+            }
+        }
+    }
+}

--- a/test/fixtures/sort-with-msgctxt-test-2.json
+++ b/test/fixtures/sort-with-msgctxt-test-2.json
@@ -1,0 +1,36 @@
+{
+    "charset": "utf-8",
+    "headers": {
+    },
+    "translations": {
+        "ctxt1": {
+            "aaaa": {
+                "msgid": "aaaa",
+                "msgstr": [ "aaaa"],
+                "msgctxt": "ctxt1"
+            }
+        },
+        "": {
+            "": {
+                "msgid": "",
+                "msgstr": [""],
+                "msgctxt": ""
+            },
+            "bbbb": {
+                "msgid": "bbbb",
+                "msgstr": [ "bbbb"],
+                "msgctxt": ""
+            },
+            "aaaa": {
+                "msgid": "aaaa",
+                "msgstr": [ "aaaa"],
+                "msgctxt": ""
+            },
+            "cccc": {
+                "msgid": "cccc",
+                "msgstr": [ "cccc"],
+                "msgctxt": ""
+            }
+        }
+    }
+}

--- a/test/fixtures/sort-with-msgctxt-test.pot
+++ b/test/fixtures/sort-with-msgctxt-test.pot
@@ -1,0 +1,15 @@
+msgid ""
+msgstr "Content-Type: text/plain;\n"
+
+msgid "aaaa"
+msgstr "aaaa"
+
+msgctxt "ctxt1"
+msgid "aaaa"
+msgstr "aaaa"
+
+msgid "bbbb"
+msgstr "bbbb"
+
+msgid "cccc"
+msgstr "cccc"

--- a/test/po-compiler-test.js
+++ b/test/po-compiler-test.js
@@ -63,5 +63,16 @@ describe('PO Compiler', function () {
       var compiled = gettextParser.po.compile(json, { sortByMsgid: true });
       expect(compiled.toString()).to.deep.equal(pot.toString());
     });
+
+    it('should sort entries with the same msgid but different msgctxt consistently', function () {
+      var json1 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/sort-with-msgctxt-test-1.json'), 'utf-8'));
+      var json2 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/sort-with-msgctxt-test-2.json'), 'utf-8'));
+      var pot = fs.readFileSync(path.join(__dirname, 'fixtures/sort-with-msgctxt-test.pot'));
+      var compiled1 = gettextParser.po.compile(json1, { sortByMsgid: true });
+      var compiled2 = gettextParser.po.compile(json2, { sortByMsgid: true });
+      expect(compiled1.toString()).to.deep.equal(compiled2.toString());
+      expect(compiled1.toString()).to.deep.equal(pot.toString());
+      expect(compiled2.toString()).to.deep.equal(pot.toString());
+    });
   });
 });

--- a/test/po-compiler-test.js
+++ b/test/po-compiler-test.js
@@ -57,19 +57,35 @@ describe('PO Compiler', function () {
   });
 
   describe('Sorting', function () {
-    it('should sort output entries by msgid', function () {
+    it('should sort output entries by msgid when `sort` is `true`', function () {
       var json = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/sort-test.json'), 'utf-8'));
       var pot = fs.readFileSync(path.join(__dirname, 'fixtures/sort-test.pot'));
-      var compiled = gettextParser.po.compile(json, { sortByMsgid: true });
+      var compiled = gettextParser.po.compile(json, { sort: true });
       expect(compiled.toString()).to.deep.equal(pot.toString());
     });
 
-    it('should sort entries with the same msgid but different msgctxt consistently', function () {
+    it('should sort entries using a custom `sort` function', function () {
+      function compareMsgidAndMsgctxt (entry1, entry2) {
+        if (entry1.msgid > entry2.msgid) {
+          return 1;
+        }
+        if (entry2.msgid > entry1.msgid) {
+          return -1;
+        }
+        if (entry1.msgctxt > entry2.msgctxt) {
+          return 1;
+        }
+        if (entry2.msgctxt > entry1.msgctxt) {
+          return -1;
+        }
+        return 0;
+      }
+
       var json1 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/sort-with-msgctxt-test-1.json'), 'utf-8'));
       var json2 = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/sort-with-msgctxt-test-2.json'), 'utf-8'));
       var pot = fs.readFileSync(path.join(__dirname, 'fixtures/sort-with-msgctxt-test.pot'));
-      var compiled1 = gettextParser.po.compile(json1, { sortByMsgid: true });
-      var compiled2 = gettextParser.po.compile(json2, { sortByMsgid: true });
+      var compiled1 = gettextParser.po.compile(json1, { sort: compareMsgidAndMsgctxt });
+      var compiled2 = gettextParser.po.compile(json2, { sort: compareMsgidAndMsgctxt });
       expect(compiled1.toString()).to.deep.equal(compiled2.toString());
       expect(compiled1.toString()).to.deep.equal(pot.toString());
       expect(compiled2.toString()).to.deep.equal(pot.toString());


### PR DESCRIPTION
A project I'm working on has instances of translation messages where the `msgid` is the same, but they have different `msgctxt` values. We use a script that crawls our code and extracts the strings, then uses this library's `po.compile()` to turn them into PO file structure before writing them to disk. We use the `sortByMsgid: true` option to attempt to minimize the changes to the PO files.

Apparently the way our script reads the files and constructs objects to make the PO file isn't consistent, because I've noticed that when there are pairs of strings with the same `msgid` but different `msgctxt` values, sometimes the order of the two entries changes in the PO file, even though those strings weren't modified in the source.

This PR provides a solution to this issue (and accompanying test) by modifying the sorting algorithm to first sort by `msgid`, and then, if the `msgid`s are equal, to sort by `msgctxt`. In addition to the test I added in this PR, I have tested this change with the project I mentioned, and it fixes the issue of "moving msgctxt values".