### PR TITLE
Add parser error checking for unescaped quotes

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -530,7 +530,14 @@ PoParserTransform.prototype._flush = function (done) {
   }
 
   if (chunk) {
-    this._parser._lexer(this._parser._toString(chunk));
+    try {
+      this._parser._lexer(this._parser._toString(chunk));
+    } catch (error) {
+      setImmediate(function () {
+        done(error);
+      });
+      return;
+    }
   }
 
   if (this._parser) {

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -43,6 +43,7 @@ function Parser (fileContents, defaultCharset) {
   this._escaped = false;
   this._node = {};
   this._state = this.states.none;
+  this._lineNumber = 1;
 
   if (typeof fileContents === 'string') {
     this._charset = 'utf-8';
@@ -120,7 +121,8 @@ Parser.prototype.symbols = {
   quotes: /["']/,
   comments: /#/,
   whitespace: /\s/,
-  key: /[\w\-[\]]/
+  key: /[\w\-[\]]/,
+  keyNames: /^(?:msgctxt|msgid(?:_plural)?|msgstr(?:\[\d+])?)$/
 };
 
 /**
@@ -133,6 +135,11 @@ Parser.prototype._lexer = function (chunk) {
 
   for (var i = 0, len = chunk.length; i < len; i++) {
     chr = chunk.charAt(i);
+
+    if (chr === '\n') {
+      this._lineNumber += 1;
+    }
+
     switch (this._state) {
       case this.states.none:
         if (chr.match(this.symbols.quotes)) {
@@ -196,6 +203,9 @@ Parser.prototype._lexer = function (chunk) {
         break;
       case this.states.key:
         if (!chr.match(this.symbols.key)) {
+          if (!this._node.value.match(this.symbols.keyNames)) {
+            throw new Error('Parsing error: Invalid key name "' + this._node.value + '" at line ' + this._lineNumber + '. This can be caused by an unescaped quote character in a msgid or msgstr value.');
+          }
           this._state = this.states.none;
           i--;
         } else {

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -204,7 +204,9 @@ Parser.prototype._lexer = function (chunk) {
       case this.states.key:
         if (!chr.match(this.symbols.key)) {
           if (!this._node.value.match(this.symbols.keyNames)) {
-            throw new Error('Parsing error: Invalid key name "' + this._node.value + '" at line ' + this._lineNumber + '. This can be caused by an unescaped quote character in a msgid or msgstr value.');
+            var err = new SyntaxError('Error parsing PO data: Invalid key name "' + this._node.value + '" at line ' + this._lineNumber + '. This can be caused by an unescaped quote character in a msgid or msgstr value.');
+            err.lineNumber = this._lineNumber;
+            throw err;
           }
           this._state = this.states.none;
           i--;

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -509,7 +509,14 @@ PoParserTransform.prototype._transform = function (chunk, encoding, done) {
 
   // chunk might be empty if it only continued of 8bit bytes and these were all cached
   if (chunk.length) {
-    this._parser._lexer(this._parser._toString(chunk));
+    try {
+      this._parser._lexer(this._parser._toString(chunk));
+    } catch (error) {
+      setImmediate(function () {
+        done(error);
+      });
+      return;
+    }
   }
 
   setImmediate(done);

--- a/test/fixtures/error-double-escaped-quote.po
+++ b/test/fixtures/error-double-escaped-quote.po
@@ -1,0 +1,21 @@
+# gettext-parser test file.
+msgid ""
+msgstr ""
+"Project-Id-Version: gettext-parser\n"
+"Report-Msgid-Bugs-To: andris@node.ee\n"
+"POT-Creation-Date: 2012-05-18 14:28:00+03:00\n"
+"PO-Revision-Date: 2012-05-18 14:37+0300\n"
+"Last-Translator: Andris Reinman <andris@kreata.ee>\n"
+"Language-Team: gettext-parser <andris@node.ee>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Poedit-Language: Estonian\n"
+"X-Poedit-Country: ESTONIA\n"
+"X-Poedit-Sourcecharset: utf-8\n"
+
+# Double-escaped double quote
+msgid "o2"
+msgstr "t2\\"-4\\""

--- a/test/fixtures/error-unescaped-quote.po
+++ b/test/fixtures/error-unescaped-quote.po
@@ -1,0 +1,21 @@
+# gettext-parser test file.
+msgid ""
+msgstr ""
+"Project-Id-Version: gettext-parser\n"
+"Report-Msgid-Bugs-To: andris@node.ee\n"
+"POT-Creation-Date: 2012-05-18 14:28:00+03:00\n"
+"PO-Revision-Date: 2012-05-18 14:37+0300\n"
+"Last-Translator: Andris Reinman <andris@kreata.ee>\n"
+"Language-Team: gettext-parser <andris@node.ee>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Poedit-Language: Estonian\n"
+"X-Poedit-Country: ESTONIA\n"
+"X-Poedit-Sourcecharset: utf-8\n"
+
+# Unescaped double quote
+msgid "o1"
+msgstr "t1"-4""

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -70,7 +70,7 @@ describe('PO Parser', () => {
       expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(invalidKeyError);
     });
 
-    it('shold throw (stream)', done => {
+    it('should throw (stream with unescaped quote)', done => {
       const poStream = fs.createReadStream(path.join(__dirname, 'fixtures/error-unescaped-quote.po'), {
         highWaterMark: 1 // ensure that any utf-8 sequences will be broken when streaming
       });

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -56,4 +56,16 @@ describe('PO Parser', () => {
       expect(parsed).to.deep.equal(json);
     });
   });
+
+  describe('parsing errors', () => {
+    it('should throw (unescaped quote)', () => {
+      const po = fs.readFileSync(path.join(__dirname, 'fixtures/error-unescaped-quote.po'));
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Parsing error: Invalid key name/);
+    });
+
+    it('should throw (double-escaped quote)', () => {
+      const po = fs.readFileSync(path.join(__dirname, 'fixtures/error-double-escaped-quote.po'));
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Parsing error: Invalid key name/);
+    });
+  });
 });

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -60,12 +60,12 @@ describe('PO Parser', () => {
   describe('parsing errors', () => {
     it('should throw (unescaped quote)', () => {
       const po = fs.readFileSync(path.join(__dirname, 'fixtures/error-unescaped-quote.po'));
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Parsing error: Invalid key name/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Error parsing PO data: Invalid key name/);
     });
 
     it('should throw (double-escaped quote)', () => {
       const po = fs.readFileSync(path.join(__dirname, 'fixtures/error-double-escaped-quote.po'));
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Parsing error: Invalid key name/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Error parsing PO data: Invalid key name/);
     });
   });
 });


### PR DESCRIPTION
This adds (one type of) error checking to the parser.

This fixes #37 

Specifically it detects and throws an error when there is an unsupported "key" (`msgid`, `msgstr`, etc.). This error occurs when there is an unescaped double quote in a string (the parser sees the double quote as the end of the string. Whatever part of the string follows is interpreted as a new key when of course it's not meant to be a key.

It also adds basic "line counting" so that the line number can be included in the error message.