### PR TITLE
Allow for named exports when importing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
 const { parse, stream } = require('./lib/poparser');
 
-module.exports = {
-  po: {
-    parse,
-    createParseStream: stream,
-    compile: require('./lib/pocompiler')
-  },
+module.exports.po = {
+  parse,
+  createParseStream: stream,
+  compile: require('./lib/pocompiler')
+};
 
-  mo: {
-    parse: require('./lib/moparser'),
-    compile: require('./lib/mocompiler')
-  }
+module.exports.mo = {
+  parse: require('./lib/moparser'),
+  compile: require('./lib/mocompiler')
 };

--- a/test/module.mjs
+++ b/test/module.mjs
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import { po, mo } from '../index.js';
+
+describe('esm module', () => {
+  it('should allow named imports', () => {
+    expect(po.parse).to.be.a('function');
+    expect(po.compile).to.be.a('function');
+    expect(mo.parse).to.be.a('function');
+    expect(mo.compile).to.be.a('function');
+  });
+});


### PR DESCRIPTION
Adds support for importing as named exports from `mjs` modules:

```js
import { po, mo } from 'gettext-parser';
```

Recent node does some parsing using `cjs-module-lexer`, and it can understand lines like `module.exports.po`, but it can't understand `module.exports = { po: ... }`.