### PR TITLE
Migrate to streamx

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -1,7 +1,6 @@
 const encoding = require('encoding');
 const sharedFuncs = require('./shared');
-const Transform = require('readable-stream').Transform;
-const util = require('util');
+const Transform = require('streamx').Transform;
 
 /**
  * Parses a PO object into translation table
@@ -442,31 +441,33 @@ Parser.prototype._finalize = function (tokens) {
  * @param {String} [defaultCharset] Default charset to use
  * @param {String} [options] Stream options
  */
-function PoParserTransform (defaultCharset, options) {
-  if (!options && defaultCharset && typeof defaultCharset === 'object') {
-    options = defaultCharset;
-    defaultCharset = undefined;
+class PoParserTransform extends Transform {
+  constructor (defaultCharset, options) {
+    if (!options && defaultCharset && typeof defaultCharset === 'object') {
+      options = defaultCharset;
+      defaultCharset = undefined;
+    }
+
+    super(options);
+
+    this.defaultCharset = defaultCharset;
+    this._parser = false;
+    this._tokens = {};
+
+    this._cache = [];
+    this._cacheSize = 0;
+
+    this.initialTreshold = options.initialTreshold || 2 * 1024;
+
+    this._writableState.objectMode = false;
+    this._readableState.objectMode = true;
   }
-
-  this.defaultCharset = defaultCharset;
-  this._parser = false;
-  this._tokens = {};
-
-  this._cache = [];
-  this._cacheSize = 0;
-
-  this.initialTreshold = options.initialTreshold || 2 * 1024;
-
-  Transform.call(this, options);
-  this._writableState.objectMode = false;
-  this._readableState.objectMode = true;
 }
-util.inherits(PoParserTransform, Transform);
 
 /**
  * Processes a chunk of the input stream
  */
-PoParserTransform.prototype._transform = function (chunk, encoding, done) {
+PoParserTransform.prototype._transform = function (chunk, done) {
   let i;
   let len = 0;
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "content-type": "^1.0.4",
     "encoding": "^0.1.13",
-    "readable-stream": "^3.6.0",
-    "safe-buffer": "^5.2.1"
+    "safe-buffer": "^5.2.1",
+    "streamx": "^2.11.3"
   },
   "devDependencies": {
     "chai": "4.3.4",


### PR DESCRIPTION
The main motivation behind this PR is that `readable-stream` is difficult for bundlers to handle due to circular dependencies (see https://github.com/nodejs/readable-stream/issues/348). I believe this might be the cause behind the discussion here: https://github.com/i18next/i18next-gettext-converter/issues/105
Other than that, `streamx` seems to have a smaller footprint and other projects like gulp [plan to migrate](https://github.com/gulpjs/vinyl-fs/issues/319) to streamx as well.
For your consideration :)
Thanks!