### PR TITLE
README - added missing filepath in writeFileSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Where
 var data = {
     ...
 };
+var output_filepath = 'output.po';
 var output = gettextParser.po.compile(data);
-require('fs').writeFileSync(output);
+require('fs').writeFileSync(output_filepath, output);
 ```
 
 ### Parse MO files
@@ -117,8 +118,9 @@ Where
 var data = {
     ...
 };
+var output_filepath = 'output.po';
 var output = gettextParser.mo.compile(data);
-require('fs').writeFileSync(output);
+require('fs').writeFileSync(output_filepath, output);
 ```
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ Where
 var data = {
     ...
 };
-var output_filepath = 'output.po';
 var output = gettextParser.po.compile(data);
-require('fs').writeFileSync(output_filepath, output);
+require('fs').writeFileSync('filename.po', output);
 ```
 
 ### Parse MO files
@@ -118,9 +117,8 @@ Where
 var data = {
     ...
 };
-var output_filepath = 'output.po';
 var output = gettextParser.mo.compile(data);
-require('fs').writeFileSync(output_filepath, output);
+require('fs').writeFileSync('filename.mo', output);
 ```
 
 ### Notes


### PR DESCRIPTION
Fixes:
```
node:internal/fs/utils:879
  throw new ERR_INVALID_ARG_TYPE(
  ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
    at Object.writeFileSync (node:fs:2146:5)
```