### PR TITLE
Extended PO parsing logic with validation rules (resolves #75)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,5 @@ module.exports = {
   },
   'rules': {
     'semi': ['error', 'always'],
-    'camelcase': 'off'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'ecmaVersion': 2018
   },
   'rules': {
-    'semi': ['error', 'always']
+    'semi': ['error', 'always'],
+    'camelcase': 'off'
   }
 }

--- a/README.md
+++ b/README.md
@@ -11,23 +11,23 @@ Include the library:
 
     var gettextParser = require("gettext-parser");
 
-
 ### Parse PO files
 
 Parse a PO file with
 
-    gettextParser.po.parse(input[, defaultCharset][, validation]) → Object
+    gettextParser.po.parse(input[, options]) → Object
 
 Where
 
   * **input** is a *po* file as a Buffer or an unicode string. Charset is converted to unicode from other encodings only if the input is a Buffer, otherwise the charset information is discarded
-  * **defaultCharset** is the charset to use if charset is not defined or is the default `"CHARSET"` (applies only if *input* is a Buffer)
-  * **validation** is a flag to turn on PO source file validation. The validation makes sure that:
+  * **options** is an optional objects with the following optinal properties:
+    * **defaultCharset** is the charset to use if charset is not defined or is the default `"CHARSET"` (applies only if *input* is a Buffer)
+    * **validation** is a flag to turn on PO source file validation. The validation makes sure that:
 
-    * there is exactly zero or one `msgid_plural` definition per translation entry; a `Multiple msgid_plural error` error gets thrown otherwise.
-    * there are no duplicate entries with exact `msgid` values; a `Duplicate msgid error` error gets thrown otherwise.
-    * the number of plural forms matches exactly the number from `nplurals` defined in `Plural-Forms` header for entries that have plural forms; a `Plural forms range error` error gets thrown otherwise.
-    * the number of `msgstr` matches exacty the one (if `msgid_plural` is not defined) or the number from `nplurals` (if `msgid_plural` is defined); a `Translation string range error` error gets thrown otherwise.
+      * there is exactly zero or one `msgid_plural` definition per translation entry; a `Multiple msgid_plural error` error gets thrown otherwise.
+      * there are no duplicate entries with exact `msgid` values; a `Duplicate msgid error` error gets thrown otherwise.
+      * the number of plural forms matches exactly the number from `nplurals` defined in `Plural-Forms` header for entries that have plural forms; a `Plural forms range error` error gets thrown otherwise.
+      * the number of `msgstr` matches exacty the one (if `msgid_plural` is not defined) or the number from `nplurals` (if `msgid_plural` is defined); a `Translation string range error` error gets thrown otherwise.
 
 Method returns gettext-parser specific translation object (see below)
 
@@ -43,13 +43,12 @@ console.log(po.translations['']); // output translations for the default context
 
 PO files can also be parsed from a stream source. After all input is processed the parser emits a single 'data' event which contains the parsed translation object.
 
-    gettextParser.po.createParseStream([defaultCharset][, streamOptions][, validation]) → Transform Stream
+    gettextParser.po.createParseStream([options][, transformOptions]) → Transform Stream
 
 Where
 
-  * **defaultCharset** is the charset to use if charset is not defined or is the default `"CHARSET"`
-  * **streamOptions** are the standard stream options
-  * **validation** is a flag to turn on PO source file validation. See [Parse PO files](#parse-po-files) section for details
+  * **options** is an optional objects, same as in `parse`. See [Parse PO files](#parse-po-files) section for details.
+  * **transformOptions** are the standard stream options.
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ Include the library:
 
 Parse a PO file with
 
-    gettextParser.po.parse(input[, defaultCharset]) → Object
+    gettextParser.po.parse(input[, defaultCharset][, validation]) → Object
 
 Where
 
   * **input** is a *po* file as a Buffer or an unicode string. Charset is converted to unicode from other encodings only if the input is a Buffer, otherwise the charset information is discarded
   * **defaultCharset** is the charset to use if charset is not defined or is the default `"CHARSET"` (applies only if *input* is a Buffer)
+  * **validation** is a flag to turn on PO source file validation. The validation makes sure that:
+
+    * there is exactly zero or one `msgid_plural` definition per translation entry; a `Multiple msgid_plural error` error gets thrown otherwise.
+    * there are no duplicate entries with exact `msgid` values; a `Duplicate msgid error` error gets thrown otherwise.
+    * the number of plural forms matches exactly the number from `nplurals` defined in `Plural-Forms` header for entries that have plural forms; a `Plural forms range error` error gets thrown otherwise.
+    * the number of `msgstr` matches exacty the one (if `msgid_plural` is not defined) or the number from `nplurals` (if `msgid_plural` is defined); a `Translation string range error` error gets thrown otherwise.
 
 Method returns gettext-parser specific translation object (see below)
 
@@ -37,12 +43,13 @@ console.log(po.translations['']); // output translations for the default context
 
 PO files can also be parsed from a stream source. After all input is processed the parser emits a single 'data' event which contains the parsed translation object.
 
-    gettextParser.po.createParseStream([defaultCharset][, streamOptions]) → Transform Stream
+    gettextParser.po.createParseStream([defaultCharset][, streamOptions][, validation]) → Transform Stream
 
 Where
 
   * **defaultCharset** is the charset to use if charset is not defined or is the default `"CHARSET"`
   * **streamOptions** are the standard stream options
+  * **validation** is a flag to turn on PO source file validation. See [Parse PO files](#parse-po-files) section for details
 
 **Example**
 
@@ -79,6 +86,8 @@ var data = {
 var output = gettextParser.po.compile(data);
 require('fs').writeFileSync('filename.po', output);
 ```
+
+### 
 
 ### Parse MO files
 

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -472,7 +472,7 @@ Parser.prototype._normalize = function (tokens) {
 
     if (!table.headers && !msgctxt && !tokens[i].msgid) {
       table.headers = sharedFuncs.parseHeader(tokens[i].msgstr[0]);
-      nplurals = sharedFuncs.parseNPluralFromHeadersSafely(table.headers);
+      nplurals = sharedFuncs.parseNPluralFromHeadersSafely(table.headers, nplurals);
     }
 
     this._validateToken(tokens[i], table.translations, msgctxt, nplurals);

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -3,27 +3,8 @@ const sharedFuncs = require('./shared');
 const Transform = require('readable-stream').Transform;
 const util = require('util');
 
-module.exports.normalizeParseArgs = normalizeParseArgs;
-module.exports.normalizeStreamArgs = normalizeStreamArgs;
 module.exports.parse = parse;
 module.exports.stream = stream;
-
-/**
- * Normalizes arguments passed into `parse` function
- *
- * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
- * @typedef {{ buffer: string | Buffer, defaultCharset?: string, validation?: boolean }} ReturnType
- * @type {{
- *    (buffer: string | Buffer): ReturnType;
- *    (buffer: string | Buffer, defaultCharset: string): ReturnType;
- *    (buffer: string | Buffer, options: Options): ReturnType;
- * }}
- */
-function normalizeParseArgs (buffer, arg1 = {}) {
-  return typeof arg1 === 'string'
-    ? { buffer, defaultCharset: arg1 }
-    : { buffer, defaultCharset: arg1.defaultCharset, validation: arg1.validation };
-}
 
 /**
  * Parses a PO object into translation table
@@ -38,39 +19,15 @@ function normalizeParseArgs (buffer, arg1 = {}) {
  *    (buffer: string | Buffer, options: Options): object;
  * }}
  */
-function parse (arg0, arg1 = {}) {
-  const {
-    buffer,
-    defaultCharset,
-    validation
-  } = normalizeParseArgs(arg0, arg1);
+function parse (buffer, optionsOrDefaultCharset = {}) {
+  const { defaultCharset, validation } = typeof optionsOrDefaultCharset === 'string'
+    ? { buffer, defaultCharset: optionsOrDefaultCharset }
+    : { buffer, defaultCharset: optionsOrDefaultCharset.defaultCharset, validation: optionsOrDefaultCharset.validation };
 
   const parser = new Parser(buffer, defaultCharset, validation);
 
   return parser.parse();
 };
-
-/**
- * Normalizes arguments passed into `stream` function
- *
- * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
- * @typedef {{ transformOptions: import('readable-stream').TransformOptions, defaultCharset?: string, validation?: boolean }} ReturnType
- * @type {{
- *    () => ReturnType;
- *    (defaultCharset: string) => ReturnType;
- *    (defaultCharset: string, transformOptions: import('readable-stream').TransformOptions) => ReturnType;
- *    (transformOptions: import('readable-stream').TransformOptions) => ReturnType;
- *    (options: Options) => ReturnType;
- *    (options: Options, transformOptions: import('readable-stream').TransformOptions) => ReturnType;
- * }}
- */
-function normalizeStreamArgs (arg0 = {}, arg1 = {}) {
-  return typeof arg0 === 'string'
-    ? { defaultCharset: arg0, transformOptions: arg1 }
-    : 'defaultCharset' in arg0 || 'validation' in arg0
-      ? { defaultCharset: arg0.defaultCharset, validation: arg0.validation, transformOptions: arg1 }
-      : { transformOptions: arg0 };
-}
 
 /**
  * Parses a PO stream, emits translation table in object mode
@@ -80,16 +37,17 @@ function normalizeStreamArgs (arg0 = {}, arg1 = {}) {
  * @param transformOptions Stream options
  * @param options Optional options with defaultCharset and validation
  * @type {{
-*    () => Stream;
-*    (defaultCharset: string) => Stream;
-*    (defaultCharset: string, transformOptions: import('readable-stream').TransformOptions) => Stream;
-*    (transformOptions: import('readable-stream').TransformOptions) => Stream;
-*    (options: Options) => Stream;
-*    (options: Options, transformOptions: import('readable-stream').TransformOptions) => Stream;
-* }}
-*/
-function stream (arg0, arg1) {
-  const { defaultCharset, validation, transformOptions } = normalizeStreamArgs(arg0, arg1);
+ *    () => Stream;
+ *    (defaultCharset: string) => Stream;
+ *    (defaultCharset: string, transformOptions: import('readable-stream').TransformOptions) => Stream;
+ *    (options: Options) => Stream;
+ *    (options: Options, transformOptions: import('readable-stream').TransformOptions) => Stream;
+ * }}
+ */
+function stream (optionsOrDefaultCharset = {}, transformOptions = {}) {
+  const { defaultCharset, validation } = typeof optionsOrDefaultCharset === 'string'
+    ? { defaultCharset: optionsOrDefaultCharset }
+    : { defaultCharset: optionsOrDefaultCharset.defaultCharset, validation: optionsOrDefaultCharset.validation };
 
   return new PoParserTransform(defaultCharset, transformOptions, validation);
 };

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -379,7 +379,7 @@ Parser.prototype._handleValues = function (tokens) {
     } else if (tokens[i].key.toLowerCase() === 'msgid_plural') {
       if (lastNode) {
         if ('msgid_plural' in lastNode) {
-          throw new SyntaxError(`Multiple msgid_plural error: entry "${lastNode.msgid}" in "${lastNode.msgctxt || ''}" has multiple msgid_plural declarations.`);
+          throw new SyntaxError(`Multiple msgid_plural error: entry "${lastNode.msgid}" in "${lastNode.msgctxt || ''}" context has multiple msgid_plural declarations.`);
         }
 
         lastNode.msgid_plural = tokens[i].value;
@@ -418,15 +418,22 @@ Parser.prototype._handleValues = function (tokens) {
  * @throws Will throw an error if token validation fails
  */
 Parser.prototype._validateToken = function (
-  { msgid = '', msgid_plural = '', msgstr = [] },
+  {
+    msgid = '',
+    msgid_plural = '', // eslint-disable-line camelcase
+    msgstr = []
+  },
   translations,
   msgctxt,
   nplurals
 ) {
   if (msgid in translations[msgctxt]) {
     throw new SyntaxError(`Duplicate msgid error: entry "${msgid}" in "${msgctxt}" context has already been declared.`);
+    // eslint-disable-next-line camelcase
   } else if (msgid_plural && msgstr.length !== nplurals) {
+    // eslint-disable-next-line camelcase
     throw new RangeError(`Plural forms range error: Expected to find ${nplurals} forms but got ${msgstr.length} for entry "${msgid_plural}" in "${msgctxt}" context.`);
+    // eslint-disable-next-line camelcase
   } else if (!msgid_plural && msgstr.length !== 1) {
     throw new RangeError(`Translation string range error: Extected 1 msgstr definitions associated with "${msgid}" in "${msgctxt}" context, found ${msgstr.length}.`);
   }

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -3,53 +3,95 @@ const sharedFuncs = require('./shared');
 const Transform = require('readable-stream').Transform;
 const util = require('util');
 
+module.exports.normalizeParseArgs = normalizeParseArgs;
+module.exports.normalizeStreamArgs = normalizeStreamArgs;
+module.exports.parse = parse;
+module.exports.stream = stream;
+
+/**
+ * Normalizes arguments passed into `parse` function
+ *
+ * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
+ * @typedef {{ buffer: string | Buffer, defaultCharset?: string, validation?: boolean }} ReturnType
+ * @type {{
+ *    (buffer: string | Buffer): ReturnType;
+ *    (buffer: string | Buffer, defaultCharset: string): ReturnType;
+ *    (buffer: string | Buffer, options: Options): ReturnType;
+ * }}
+ */
+function normalizeParseArgs (buffer, arg1 = {}) {
+  return typeof arg1 === 'string'
+    ? { buffer, defaultCharset: arg1 }
+    : { buffer, defaultCharset: arg1.defaultCharset, validation: arg1.validation };
+}
+
 /**
  * Parses a PO object into translation table
  *
+ * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
  * @param buffer PO object
- * @param defaultCharset Default charset to use
- * @param validation Enables validation of parsed content, if set to true
+ * @param [defaultCharset] Default charset to use
+ * @param {Options} [options] Optional options with defaultCharset and validation
  * @type {{
  *    (buffer: string | Buffer): object;
  *    (buffer: string | Buffer, defaultCharset: string): object;
- *    (buffer: string | Buffer, defaultCharset: string, validation: boolean): object;
- *    (buffer: string | Buffer, validation: boolean): object;
+ *    (buffer: string | Buffer, options: Options): object;
  * }}
  */
-module.exports.parse = function (buffer, defaultCharset, validation) {
-  const args = sharedFuncs.unshiftOptionalArgs(
-    ['string', 'boolean'],
-    [defaultCharset, validation]
-  );
-  const parser = new Parser(buffer, ...args);
+function parse (arg0, arg1 = {}) {
+  const {
+    buffer,
+    defaultCharset,
+    validation
+  } = normalizeParseArgs(arg0, arg1);
+
+  const parser = new Parser(buffer, defaultCharset, validation);
 
   return parser.parse();
 };
 
 /**
- * Parses a PO stream, emits translation table in object mode
-
- * @param defaultCharset Default charset to use
- * @param options Stream options
- * @param validation Enables validation of parsed content, if set to true
+ * Normalizes arguments passed into `stream` function
+ *
+ * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
+ * @typedef {{ transformOptions: import('readable-stream').TransformOptions, defaultCharset?: string, validation?: boolean }} ReturnType
  * @type {{
- *    () => Stream;
- *    (defaultCharset: string) => Stream;
- *    (defaultCharset: string, options: import('readable-stream').TransformOptions) => Stream;
- *    (defaultCharset: string, options: import('readable-stream').TransformOptions, validation: boolean) => Stream;
- *    (defaultCharset: string, validation: boolean) => Stream;
- *    (options: import('readable-stream').TransformOptions) => Stream;
- *    (options: import('readable-stream').TransformOptions, validation: boolean) => Stream;
- *    (validation: boolean) => Stream;
+ *    () => ReturnType;
+ *    (defaultCharset: string) => ReturnType;
+ *    (defaultCharset: string, transformOptions: import('readable-stream').TransformOptions) => ReturnType;
+ *    (transformOptions: import('readable-stream').TransformOptions) => ReturnType;
+ *    (options: Options) => ReturnType;
+ *    (options: Options, transformOptions: import('readable-stream').TransformOptions) => ReturnType;
  * }}
  */
-module.exports.stream = function (defaultCharset, options, validation) {
-  const args = sharedFuncs.unshiftOptionalArgs(
-    ['string', 'object', 'boolean'],
-    [defaultCharset, options, validation]
-  );
+function normalizeStreamArgs (arg0 = {}, arg1 = {}) {
+  return typeof arg0 === 'string'
+    ? { defaultCharset: arg0, transformOptions: arg1 }
+    : 'defaultCharset' in arg0 || 'validation' in arg0
+      ? { defaultCharset: arg0.defaultCharset, validation: arg0.validation, transformOptions: arg1 }
+      : { transformOptions: arg0 };
+}
 
-  return new PoParserTransform(...args);
+/**
+ * Parses a PO stream, emits translation table in object mode
+ *
+ * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
+ * @param defaultCharset Default charset to use
+ * @param transformOptions Stream options
+ * @param options Optional options with defaultCharset and validation
+ * @type {{
+*    () => Stream;
+*    (defaultCharset: string) => Stream;
+*    (defaultCharset: string, transformOptions: import('readable-stream').TransformOptions) => Stream;
+*    (transformOptions: import('readable-stream').TransformOptions) => Stream;
+*    (options: Options) => Stream;
+*    (options: Options, transformOptions: import('readable-stream').TransformOptions) => Stream;
+* }}
+*/
+function stream (arg0, arg1) {
+  const { defaultCharset, validation, transformOptions } = normalizeStreamArgs(arg0, arg1);
+
+  return new PoParserTransform(defaultCharset, transformOptions, validation);
 };
 
 /**

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -6,25 +6,50 @@ const util = require('util');
 /**
  * Parses a PO object into translation table
  *
- * @param {Buffer|String} buffer PO object
- * @param {String} [defaultCharset] Default charset to use
- * @return {Object} Translation object
+ * @param buffer PO object
+ * @param defaultCharset Default charset to use
+ * @param validation Enables validation of parsed content, if set to true
+ * @type {{
+ *    (buffer: string | Buffer): object;
+ *    (buffer: string | Buffer, defaultCharset: string): object;
+ *    (buffer: string | Buffer, defaultCharset: string, validation: boolean): object;
+ *    (buffer: string | Buffer, validation: boolean): object;
+ * }}
  */
-module.exports.parse = function (buffer, defaultCharset) {
-  const parser = new Parser(buffer, defaultCharset);
+module.exports.parse = function (buffer, defaultCharset, validation) {
+  const unshiftedOptionalArgs = sharedFuncs.unshiftOptionalArgs(
+    ['string', 'boolean'],
+    [defaultCharset, validation]
+  );
+  const parser = new Parser(buffer, unshiftedOptionalArgs[0], unshiftedOptionalArgs[1]);
 
   return parser.parse();
 };
 
 /**
  * Parses a PO stream, emits translation table in object mode
- *
- * @param {String} [defaultCharset] Default charset to use
- * @param {String} [options] Stream options
- * @return {Stream} Transform stream
+
+ * @param defaultCharset Default charset to use
+ * @param options Stream options
+ * @param validation Enables validation of parsed content, if set to true
+ * @type {{
+ *    () => Stream;
+ *    (defaultCharset: string) => Stream;
+ *    (defaultCharset: string, options: import('readable-stream').TransformOptions) => Stream;
+ *    (defaultCharset: string, options: import('readable-stream').TransformOptions, validation: boolean) => Stream;
+ *    (defaultCharset: string, validation: boolean) => Stream;
+ *    (options: import('readable-stream').TransformOptions) => Stream;
+ *    (options: import('readable-stream').TransformOptions, validation: boolean) => Stream;
+ *    (validation: boolean) => Stream;
+ * }}
  */
-module.exports.stream = function (defaultCharset, options) {
-  return new PoParserTransform(defaultCharset, options);
+module.exports.stream = function (defaultCharset, options, validation) {
+  const args = sharedFuncs.unshiftOptionalArgs(
+    ['string', 'string', 'boolean'],
+    [defaultCharset, options, validation]
+  );
+
+  return new PoParserTransform(args[0], args[1], args[2]);
 };
 
 /**
@@ -33,9 +58,11 @@ module.exports.stream = function (defaultCharset, options) {
  *
  * @constructor
  * @param {Buffer|String} fileContents PO object
- * @param {String} [defaultCharset] Default charset to use
+ * @param {String} [defaultCharset=iso-8859-1] Default charset to use
+ * @param {Boolean} [validation=false] Enables validation of parsed content, if set to true
  */
-function Parser (fileContents, defaultCharset = 'iso-8859-1') {
+function Parser (fileContents, defaultCharset = 'iso-8859-1', validation = false) {
+  this._validation = validation;
   this._charset = defaultCharset;
 
   this._lex = [];
@@ -378,7 +405,7 @@ Parser.prototype._handleValues = function (tokens) {
       response.push(lastNode);
     } else if (tokens[i].key.toLowerCase() === 'msgid_plural') {
       if (lastNode) {
-        if ('msgid_plural' in lastNode) {
+        if (this._validation && 'msgid_plural' in lastNode) {
           throw new SyntaxError(`Multiple msgid_plural error: entry "${lastNode.msgid}" in "${lastNode.msgctxt || ''}" context has multiple msgid_plural declarations.`);
         }
 
@@ -427,6 +454,10 @@ Parser.prototype._validateToken = function (
   msgctxt,
   nplurals
 ) {
+  if (!this._validation) {
+    return;
+  }
+
   if (msgid in translations[msgctxt]) {
     throw new SyntaxError(`Duplicate msgid error: entry "${msgid}" in "${msgctxt}" context has already been declared.`);
     // eslint-disable-next-line camelcase
@@ -512,15 +543,12 @@ Parser.prototype._finalize = function (tokens) {
  *
  * @constructor
  * @param {String} [defaultCharset] Default charset to use
- * @param {String} [options] Stream options
+ * @param {import('readable-stream').TransformOptions} [options] Stream options
+ * @param {Boolean} [validation=false] Enables validation of parsed content, if set to true
  */
-function PoParserTransform (defaultCharset, options) {
-  if (!options && defaultCharset && typeof defaultCharset === 'object') {
-    options = defaultCharset;
-    defaultCharset = undefined;
-  }
-
+function PoParserTransform (defaultCharset, options, validation) {
   this.defaultCharset = defaultCharset;
+  this.validation = validation;
   this._parser = false;
   this._tokens = {};
 
@@ -559,7 +587,7 @@ PoParserTransform.prototype._transform = function (chunk, encoding, done) {
       this._cache = [];
     }
 
-    this._parser = new Parser(chunk, this.defaultCharset);
+    this._parser = new Parser(chunk, this.defaultCharset, this.validation);
   } else if (this._cacheSize) {
     // this only happens if we had an uncompleted 8bit sequence from the last iteration
     this._cache.push(chunk);

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -17,11 +17,11 @@ const util = require('util');
  * }}
  */
 module.exports.parse = function (buffer, defaultCharset, validation) {
-  const unshiftedOptionalArgs = sharedFuncs.unshiftOptionalArgs(
+  const args = sharedFuncs.unshiftOptionalArgs(
     ['string', 'boolean'],
     [defaultCharset, validation]
   );
-  const parser = new Parser(buffer, unshiftedOptionalArgs[0], unshiftedOptionalArgs[1]);
+  const parser = new Parser(buffer, ...args);
 
   return parser.parse();
 };
@@ -45,11 +45,11 @@ module.exports.parse = function (buffer, defaultCharset, validation) {
  */
 module.exports.stream = function (defaultCharset, options, validation) {
   const args = sharedFuncs.unshiftOptionalArgs(
-    ['string', 'string', 'boolean'],
+    ['string', 'object', 'boolean'],
     [defaultCharset, options, validation]
   );
 
-  return new PoParserTransform(args[0], args[1], args[2]);
+  return new PoParserTransform(...args);
 };
 
 /**

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -10,21 +10,11 @@ module.exports.stream = stream;
  * Parses a PO object into translation table
  *
  * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
- * @param buffer PO object
- * @param [defaultCharset] Default charset to use
+ * @param {string | Buffer} input PO object
  * @param {Options} [options] Optional options with defaultCharset and validation
- * @type {{
- *    (buffer: string | Buffer): object;
- *    (buffer: string | Buffer, defaultCharset: string): object;
- *    (buffer: string | Buffer, options: Options): object;
- * }}
  */
-function parse (buffer, optionsOrDefaultCharset = {}) {
-  const { defaultCharset, validation } = typeof optionsOrDefaultCharset === 'string'
-    ? { buffer, defaultCharset: optionsOrDefaultCharset }
-    : { buffer, defaultCharset: optionsOrDefaultCharset.defaultCharset, validation: optionsOrDefaultCharset.validation };
-
-  const parser = new Parser(buffer, defaultCharset, validation);
+function parse (input, options = {}) {
+  const parser = new Parser(input, options);
 
   return parser.parse();
 };
@@ -33,35 +23,23 @@ function parse (buffer, optionsOrDefaultCharset = {}) {
  * Parses a PO stream, emits translation table in object mode
  *
  * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
- * @param defaultCharset Default charset to use
- * @param transformOptions Stream options
- * @param options Optional options with defaultCharset and validation
- * @type {{
- *    () => Stream;
- *    (defaultCharset: string) => Stream;
- *    (defaultCharset: string, transformOptions: import('readable-stream').TransformOptions) => Stream;
- *    (options: Options) => Stream;
- *    (options: Options, transformOptions: import('readable-stream').TransformOptions) => Stream;
- * }}
+ * @param {Options} [options] Optional options with defaultCharset and validation
+ * @param {import('readable-stream').TransformOptions} [transformOptions] Optional stream options
  */
-function stream (optionsOrDefaultCharset = {}, transformOptions = {}) {
-  const { defaultCharset, validation } = typeof optionsOrDefaultCharset === 'string'
-    ? { defaultCharset: optionsOrDefaultCharset }
-    : { defaultCharset: optionsOrDefaultCharset.defaultCharset, validation: optionsOrDefaultCharset.validation };
-
-  return new PoParserTransform(defaultCharset, transformOptions, validation);
+function stream (options = {}, transformOptions = {}) {
+  return new PoParserTransform(options, transformOptions);
 };
 
 /**
  * Creates a PO parser object. If PO object is a string,
  * UTF-8 will be used as the charset
  *
+ * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
  * @constructor
- * @param {Buffer|String} fileContents PO object
- * @param {String} [defaultCharset=iso-8859-1] Default charset to use
- * @param {Boolean} [validation=false] Enables validation of parsed content, if set to true
+ * @param {string | Buffer} fileContents PO object
+ * @param {Options} options Options with defaultCharset and validation
  */
-function Parser (fileContents, defaultCharset = 'iso-8859-1', validation = false) {
+function Parser (fileContents, { defaultCharset = 'iso-8859-1', validation = false }) {
   this._validation = validation;
   this._charset = defaultCharset;
 
@@ -541,23 +519,22 @@ Parser.prototype._finalize = function (tokens) {
 /**
  * Creates a transform stream for parsing PO input
  *
+ * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
  * @constructor
- * @param {String} [defaultCharset] Default charset to use
- * @param {import('readable-stream').TransformOptions} [options] Stream options
- * @param {Boolean} [validation=false] Enables validation of parsed content, if set to true
+ * @param {Options} options Optional options with defaultCharset and validation
+ * @param {import('readable-stream').TransformOptions} transformOptions Optional stream options
  */
-function PoParserTransform (defaultCharset, options, validation) {
-  this.defaultCharset = defaultCharset;
-  this.validation = validation;
+function PoParserTransform (options, transformOptions) {
+  this.options = options;
   this._parser = false;
   this._tokens = {};
 
   this._cache = [];
   this._cacheSize = 0;
 
-  this.initialTreshold = options.initialTreshold || 2 * 1024;
+  this.initialTreshold = transformOptions.initialTreshold || 2 * 1024;
 
-  Transform.call(this, options);
+  Transform.call(this, transformOptions);
   this._writableState.objectMode = false;
   this._readableState.objectMode = true;
 }
@@ -587,7 +564,7 @@ PoParserTransform.prototype._transform = function (chunk, encoding, done) {
       this._cache = [];
     }
 
-    this._parser = new Parser(chunk, this.defaultCharset, this.validation);
+    this._parser = new Parser(chunk, this.options);
   } else if (this._cacheSize) {
     // this only happens if we had an uncompleted 8bit sequence from the last iteration
     this._cache.push(chunk);
@@ -640,7 +617,7 @@ PoParserTransform.prototype._flush = function (done) {
   }
 
   if (!this._parser && chunk) {
-    this._parser = new Parser(chunk, this.defaultCharset);
+    this._parser = new Parser(chunk, this.options);
   }
 
   if (chunk) {

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -378,6 +378,10 @@ Parser.prototype._handleValues = function (tokens) {
       response.push(lastNode);
     } else if (tokens[i].key.toLowerCase() === 'msgid_plural') {
       if (lastNode) {
+        if ('msgid_plural' in lastNode) {
+          throw new SyntaxError(`Multiple msgid_plural error: entry "${lastNode.msgid}" in "${lastNode.msgctxt || ''}" has multiple msgid_plural declarations.`);
+        }
+
         lastNode.msgid_plural = tokens[i].value;
       }
 
@@ -405,6 +409,30 @@ Parser.prototype._handleValues = function (tokens) {
 };
 
 /**
+ * Validate token
+ *
+ * @param {Object} token Parsed token
+ * @param {Object} translations Translation table
+ * @param {string} msgctxt Message entry context
+ * @param {number} nplurals Number of epected plural forms
+ * @throws Will throw an error if token validation fails
+ */
+Parser.prototype._validateToken = function (
+  { msgid = '', msgid_plural = '', msgstr = [] },
+  translations,
+  msgctxt,
+  nplurals
+) {
+  if (msgid in translations[msgctxt]) {
+    throw new SyntaxError(`Duplicate msgid error: entry "${msgid}" in "${msgctxt}" context has already been declared.`);
+  } else if (msgid_plural && msgstr.length !== nplurals) {
+    throw new RangeError(`Plural forms range error: Expected to find ${nplurals} forms but got ${msgstr.length} for entry "${msgid_plural}" in "${msgctxt}" context.`);
+  } else if (!msgid_plural && msgstr.length !== 1) {
+    throw new RangeError(`Translation string range error: Extected 1 msgstr definitions associated with "${msgid}" in "${msgctxt}" context, found ${msgstr.length}.`);
+  }
+};
+
+/**
  * Compose a translation table from tokens object
  *
  * @param {Object} tokens Parsed tokens
@@ -416,6 +444,7 @@ Parser.prototype._normalize = function (tokens) {
     headers: undefined,
     translations: {}
   };
+  let nplurals = 1;
   let msgctxt;
 
   for (let i = 0, len = tokens.length; i < len; i++) {
@@ -443,7 +472,10 @@ Parser.prototype._normalize = function (tokens) {
 
     if (!table.headers && !msgctxt && !tokens[i].msgid) {
       table.headers = sharedFuncs.parseHeader(tokens[i].msgstr[0]);
+      nplurals = sharedFuncs.parseNPluralFromHeadersSafely(table.headers);
     }
+
+    this._validateToken(tokens[i], table.translations, msgctxt, nplurals);
 
     table.translations[msgctxt][tokens[i].msgid] = tokens[i];
   }

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,10 +1,12 @@
 module.exports.parseHeader = parseHeader;
+module.exports.parseNPluralFromHeadersSafely = parseNPluralFromHeadersSafely;
 module.exports.generateHeader = generateHeader;
 module.exports.formatCharset = formatCharset;
 module.exports.foldLine = foldLine;
 module.exports.compareMsgid = compareMsgid;
 
 // see https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html
+const PLURAL_FORMS = 'Plural-Forms';
 const HEADERS = new Map([
   ['project-id-version', 'Project-Id-Version'],
   ['report-msgid-bugs-to', 'Report-Msgid-Bugs-To'],
@@ -15,10 +17,12 @@ const HEADERS = new Map([
   ['language', 'Language'],
   ['content-type', 'Content-Type'],
   ['content-transfer-encoding', 'Content-Transfer-Encoding'],
-  ['plural-forms', 'Plural-Forms']
+  ['plural-forms', PLURAL_FORMS]
 ]);
 
 module.exports.HEADERS = HEADERS;
+
+const PLURAL_FORM_HEADER_NPLURALS_REGEX = /nplurals\s*=\s*(?<nplurals>\d+)/;
 
 /**
  * Parses a header string into an object of key-value pairs
@@ -42,6 +46,26 @@ function parseHeader (str = '') {
 
       return headers;
     }, {});
+}
+
+/**
+ * Attempts to safely parse 'nplurals" value from "Plural-Forms" header
+ *
+ * @param {Object} [headers = {}] An object with parsed headers
+ * @returns {{ nplurals: number}} An object with parsed result
+ */
+function parseNPluralFromHeadersSafely (headers = {}) {
+  const pluralForms = headers[PLURAL_FORMS];
+
+  if (!pluralForms) {
+    return 1;
+  }
+
+  const {
+    groups: { nplurals } = { nplurals: '1' }
+  } = pluralForms.match(PLURAL_FORM_HEADER_NPLURALS_REGEX) || {};
+
+  return Number.parseInt(nplurals, 10);
 }
 
 /**

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -4,6 +4,7 @@ module.exports.generateHeader = generateHeader;
 module.exports.formatCharset = formatCharset;
 module.exports.foldLine = foldLine;
 module.exports.compareMsgid = compareMsgid;
+module.exports.unshiftOptionalArgs = unshiftOptionalArgs;
 
 // see https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html
 const PLURAL_FORMS = 'Plural-Forms';
@@ -152,6 +153,7 @@ function foldLine (str, maxLen = 76) {
 
 /**
  * Comparator function for comparing msgid
+ *
  * @param {Object} object with msgid prev
  * @param {Object} object with msgid next
  * @returns {number} comparator index
@@ -166,4 +168,33 @@ function compareMsgid ({ msgid: left }, { msgid: right }) {
   }
 
   return 0;
+}
+
+/**
+ * Collects and undoes parameter shifting of a list of optional arguments
+ *
+ * @param {("undefined" | "object" | "boolean" | "number" | "bigint" | "string" | "symbol" | "function")[]} types An exhaustive ordered list of expected types of arguments
+ * @param {any[]} args An actual list of passed arguments
+ * @returns {any[]}
+ */
+function unshiftOptionalArgs (types, args) {
+  const result = [];
+
+  for (let typeIndex = 0, argIndex = 0; typeIndex < types.length; typeIndex++) {
+    const arg = args[argIndex];
+    const type = types[typeIndex];
+
+    // eslint-disable-next-line valid-typeof
+    if (typeof arg === type) {
+      argIndex += 1;
+      result.push(arg);
+    } else {
+      if (arg === undefined) {
+        argIndex += 1;
+      }
+      result.push(undefined);
+    }
+  }
+
+  return result;
 }

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -52,20 +52,20 @@ function parseHeader (str = '') {
  * Attempts to safely parse 'nplurals" value from "Plural-Forms" header
  *
  * @param {Object} [headers = {}] An object with parsed headers
- * @returns {{ nplurals: number}} An object with parsed result
+ * @returns {number} Parsed result
  */
-function parseNPluralFromHeadersSafely (headers = {}) {
+function parseNPluralFromHeadersSafely (headers = {}, fallback = 1) {
   const pluralForms = headers[PLURAL_FORMS];
 
   if (!pluralForms) {
-    return 1;
+    return fallback;
   }
 
   const {
-    groups: { nplurals } = { nplurals: '1' }
+    groups: { nplurals } = { nplurals: '' + fallback }
   } = pluralForms.match(PLURAL_FORM_HEADER_NPLURALS_REGEX) || {};
 
-  return Number.parseInt(nplurals, 10);
+  return parseInt(nplurals, 10) || fallback;
 }
 
 /**

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -4,7 +4,6 @@ module.exports.generateHeader = generateHeader;
 module.exports.formatCharset = formatCharset;
 module.exports.foldLine = foldLine;
 module.exports.compareMsgid = compareMsgid;
-module.exports.unshiftOptionalArgs = unshiftOptionalArgs;
 
 // see https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html
 const PLURAL_FORMS = 'Plural-Forms';
@@ -168,33 +167,4 @@ function compareMsgid ({ msgid: left }, { msgid: right }) {
   }
 
   return 0;
-}
-
-/**
- * Collects and undoes parameter shifting of a list of optional arguments
- *
- * @param {("undefined" | "object" | "boolean" | "number" | "bigint" | "string" | "symbol" | "function")[]} types An exhaustive ordered list of expected types of arguments
- * @param {any[]} args An actual list of passed arguments
- * @returns {any[]}
- */
-function unshiftOptionalArgs (types, args) {
-  const result = [];
-
-  for (let typeIndex = 0, argIndex = 0; typeIndex < types.length; typeIndex++) {
-    const arg = args[argIndex];
-    const type = types[typeIndex];
-
-    // eslint-disable-next-line valid-typeof
-    if (typeof arg === type) {
-      argIndex += 1;
-      result.push(arg);
-    } else {
-      if (arg === undefined) {
-        argIndex += 1;
-      }
-      result.push(undefined);
-    }
-  }
-
-  return result;
 }

--- a/test/fixtures/headers-known.json
+++ b/test/fixtures/headers-known.json
@@ -1,0 +1,21 @@
+{
+    "charset": "utf-8",
+    "headers": {
+        "Project-Id-Version": "project 1.0.2",
+        "Content-Type": "text/plain; charset=utf-8",
+        "Content-Transfer-Encoding": "8bit",
+        "Plural-Forms": "nplurals=2; plural=(n!=1);",
+        "Mime-Version": "1.0",
+        "X-Poedit-SourceCharset": "UTF-8"
+    },
+    "translations": {
+        "": {
+            "": {
+                "msgid": "",
+                "msgstr": [
+                    "Project-Id-Version: project 1.0.2\nContent-Type: text/plain; charset=utf-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n!=1);\nMime-Version: 1.0\nX-Poedit-SourceCharset: UTF-8\n"
+                ]
+            }
+        }
+    }
+}

--- a/test/fixtures/headers-known.po
+++ b/test/fixtures/headers-known.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"

--- a/test/fixtures/validate-context-duplicate-entries.po
+++ b/test/fixtures/validate-context-duplicate-entries.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Plural string in "c1" context
+msgctxt "c1"
+msgid "o1-1"
+msgid_plural "o1-2"
+msgstr[0] "t1-1"
+msgstr[1] "t1-2"
+
+# Plural string in "c2" context
+msgctxt "c2"
+msgid "o1-1"
+msgid_plural "o1-2"
+msgstr[0] "t1-1"
+msgstr[1] "t1-2"
+
+# Plural string duplicate in "c2" context
+msgctxt "c2"
+msgid "o1-1"
+msgid_plural "o1-2"
+msgstr[0] "t1-1"
+msgstr[1] "t1-2"

--- a/test/fixtures/validate-duplicate-msgid.po
+++ b/test/fixtures/validate-duplicate-msgid.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Normal string
+msgid "o1"
+msgstr "t1"
+
+# Normal string duplicate
+msgid "o1"
+msgstr "t2"

--- a/test/fixtures/validate-missing-msgid-plural.po
+++ b/test/fixtures/validate-missing-msgid-plural.po
@@ -1,0 +1,15 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Plural string
+msgid "o1-1"
+#. msgid_plural must be defined
+#. msgid_plural "o1-2\n"
+msgstr[0] "t1-1"
+msgstr[1] "t1-2"

--- a/test/fixtures/validate-missing-msgstr.po
+++ b/test/fixtures/validate-missing-msgstr.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Normal string
+msgid "o1"
+#. Missing msgstr
+#. msgstr "t1"

--- a/test/fixtures/validate-redundant-msgid-plural.po
+++ b/test/fixtures/validate-redundant-msgid-plural.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Plural string
+msgid "o1-1"
+msgid_plural "o1-2"
+#. redundant msgid_plural must be defined
+msgid_plural "o1-3"
+msgstr[0] "o1-1"
+msgstr[1] "o1-2"

--- a/test/fixtures/validate-too-few-plural-forms.po
+++ b/test/fixtures/validate-too-few-plural-forms.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Plural string
+msgid "o1-1"
+msgid_plural "o1-2"
+msgstr[0] "t1-1"
+msgstr[1] "t1-2"
+#. a missing plural form
+#. msgstr[2] "t1-3"

--- a/test/fixtures/validate-too-many-plural-forms.po
+++ b/test/fixtures/validate-too-many-plural-forms.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: project 1.0.2\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Mime-Version: 1.0\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+# Plural string
+msgid "o1-1"
+msgid_plural "o1-2"
+msgstr[0] "t1-1"
+msgstr[1] "t1-2"
+#. a redundant plural form
+msgstr[2] "t1-3"

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -3,7 +3,6 @@ const { promisify } = require('util');
 const path = require('path');
 const fs = require('fs');
 const gettextParser = require('..');
-const { normalizeParseArgs, normalizeStreamArgs } = require('../lib/poparser');
 
 const readFile = promisify(fs.readFile);
 
@@ -11,76 +10,6 @@ const expect = chai.expect;
 chai.config.includeStack = true;
 
 describe('PO Parser', () => {
-  describe('normalizeParseArgs', () => {
-    [
-      {
-        input: ['foo'],
-        expected: { buffer: 'foo', defaultCharset: undefined, validation: undefined }
-      },
-      {
-        input: ['foo', 'bar'],
-        expected: { buffer: 'foo', defaultCharset: 'bar' }
-      },
-      {
-        input: ['foo', { defaultCharset: 'bar' }],
-        expected: { buffer: 'foo', defaultCharset: 'bar', validation: undefined }
-      },
-      {
-        input: ['foo', { validation: true }],
-        expected: { buffer: 'foo', defaultCharset: undefined, validation: true }
-      },
-      {
-        input: ['foo', { defaultCharset: 'bar', validation: true }],
-        expected: { buffer: 'foo', defaultCharset: 'bar', validation: true }
-      }
-    ].forEach(({ input, expected }) => {
-      it(`should return normalized arguments for argument list of ${JSON.stringify(input)}`, () => {
-        expect(normalizeParseArgs(...input)).to.deep.equal(expected);
-      });
-    });
-  });
-
-  describe('normalizeStreamArgs', () => {
-    [
-      {
-        input: [],
-        expected: { transformOptions: {} }
-      },
-      {
-        input: ['foo'],
-        expected: { defaultCharset: 'foo', transformOptions: {} }
-      },
-      {
-        input: ['foo', { initialTreshold: 123 }],
-        expected: { defaultCharset: 'foo', transformOptions: { initialTreshold: 123 } }
-      },
-      {
-        input: [{ initialTreshold: 123 }],
-        expected: { transformOptions: { initialTreshold: 123 } }
-      },
-      {
-        input: [{ validation: true }],
-        expected: { defaultCharset: undefined, validation: true, transformOptions: {} }
-      },
-      {
-        input: [{ defaultCharset: 'foo' }],
-        expected: { defaultCharset: 'foo', validation: undefined, transformOptions: {} }
-      },
-      {
-        input: [{ defaultCharset: 'foo', validation: true }],
-        expected: { defaultCharset: 'foo', validation: true, transformOptions: {} }
-      },
-      {
-        input: [{ defaultCharset: 'foo', validation: true }, { initialTreshold: 123 }],
-        expected: { defaultCharset: 'foo', validation: true, transformOptions: { initialTreshold: 123 } }
-      }
-    ].forEach(({ input, expected }) => {
-      it(`should return normalized arguments for argument list of ${JSON.stringify(input)}`, () => {
-        expect(normalizeStreamArgs(...input)).to.deep.equal(expected);
-      });
-    });
-  });
-
   describe('headers', () => {
     it('should detect charset in header', async () => {
       const [po, json] = await Promise.all([

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -37,7 +37,7 @@ describe('PO Parser', () => {
   describe('UTF-8', () => {
     it('should parse', async () => {
       const [po, json] = await Promise.all([
-        readFile(path.join(__dirname, 'fixtures/utf8.po'), 'utf8'),
+        readFile(path.join(__dirname, 'fixtures/utf8.po')),
         readFile(path.join(__dirname, 'fixtures/utf8-po.json'), 'utf8')
       ]);
 
@@ -98,7 +98,7 @@ describe('PO Parser', () => {
     });
   });
 
-  describe.only('parsing errors', () => {
+  describe('parsing errors', () => {
     const invalidKeyError = /Error parsing PO data: Invalid key name/;
 
     it('should throw (unescaped quote)', async () => {
@@ -158,7 +158,7 @@ describe('PO Parser', () => {
       expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Duplicate msgid error: entry "o1-1" in "c2"/);
     });
 
-    it.only('should throw (an entry with multiple "msgid_plural")', async () => {
+    it('should throw (an entry with multiple "msgid_plural")', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-redundant-msgid-plural.po'));
 
       expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Multiple msgid_plural error: entry "o1-1"/);

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -131,37 +131,37 @@ describe('PO Parser', () => {
     it('should throw (an entry has too few plural forms)', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-too-few-plural-forms.po'));
 
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Plural forms range error/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw('Plural forms range error: Expected to find 3 forms but got 2 for entry "o1-2" in "" context.');
     });
 
     it('should throw (an entry has too many plural forms)', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-too-many-plural-forms.po'));
 
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Plural forms range error/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw('Plural forms range error: Expected to find 2 forms but got 3 for entry "o1-2" in "" context.');
     });
 
     it('should throw (an entry misses "msgid_plural")', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgid-plural.po'));
 
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Translation string range error/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw('Translation string range error: Extected 1 msgstr definitions associated with "o1-1" in "" context, found 2.');
     });
 
     it('should throw (an entry misses single "msgstr")', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgstr.po'));
 
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Translation string range error/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw('Translation string range error: Extected 1 msgstr definitions associated with "o1" in "" context, found 0.');
     });
 
     it('should throw (duplicate entries found in the same context)', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-context-duplicate-entries.po'));
 
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Duplicate msgid error: entry "o1-1" in "c2"/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw('Duplicate msgid error: entry "o1-1" in "c2" context has already been declared.');
     });
 
     it('should throw (an entry with multiple "msgid_plural")', async () => {
       const po = await readFile(path.join(__dirname, 'fixtures/validate-redundant-msgid-plural.po'));
 
-      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Multiple msgid_plural error: entry "o1-1"/);
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw('Multiple msgid_plural error: entry "o1-1" in "" context has multiple msgid_plural declarations.');
     });
   });
 });

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -21,12 +21,23 @@ describe('PO Parser', () => {
 
       expect(parsed).to.deep.equal(JSON.parse(json));
     });
+
+    it('should parse all known headers', async () => {
+      const [po, json] = await Promise.all([
+        readFile(path.join(__dirname, 'fixtures/headers-known.po')),
+        readFile(path.join(__dirname, 'fixtures/headers-known.json'), 'utf8')
+      ]);
+
+      const parsed = gettextParser.po.parse(po);
+
+      expect(parsed).to.deep.equal(JSON.parse(json));
+    });
   });
 
   describe('UTF-8', () => {
     it('should parse', async () => {
       const [po, json] = await Promise.all([
-        readFile(path.join(__dirname, 'fixtures/utf8.po')),
+        readFile(path.join(__dirname, 'fixtures/utf8.po'), 'utf8'),
         readFile(path.join(__dirname, 'fixtures/utf8-po.json'), 'utf8')
       ]);
 
@@ -87,7 +98,7 @@ describe('PO Parser', () => {
     });
   });
 
-  describe('parsing errors', () => {
+  describe.only('parsing errors', () => {
     const invalidKeyError = /Error parsing PO data: Invalid key name/;
 
     it('should throw (unescaped quote)', async () => {
@@ -115,6 +126,42 @@ describe('PO Parser', () => {
         expect(error.message).to.match(invalidKeyError);
         done();
       });
+    });
+
+    it('should throw (an entry has too few plural forms)', async () => {
+      const po = await readFile(path.join(__dirname, 'fixtures/validate-too-few-plural-forms.po'));
+
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Plural forms range error/);
+    });
+
+    it('should throw (an entry has too many plural forms)', async () => {
+      const po = await readFile(path.join(__dirname, 'fixtures/validate-too-many-plural-forms.po'));
+
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Plural forms range error/);
+    });
+
+    it('should throw (an entry misses "msgid_plural")', async () => {
+      const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgid-plural.po'));
+
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Translation string range error/);
+    });
+
+    it('should throw (an entry misses single "msgstr")', async () => {
+      const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgstr.po'));
+
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Translation string range error/);
+    });
+
+    it('should throw (duplicate entries found in the same context)', async () => {
+      const po = await readFile(path.join(__dirname, 'fixtures/validate-context-duplicate-entries.po'));
+
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Duplicate msgid error: entry "o1-1" in "c2"/);
+    });
+
+    it.only('should throw (an entry with multiple "msgid_plural")', async () => {
+      const po = await readFile(path.join(__dirname, 'fixtures/validate-redundant-msgid-plural.po'));
+
+      expect(gettextParser.po.parse.bind(gettextParser.po, po)).to.throw(/Multiple msgid_plural error: entry "o1-1"/);
     });
   });
 });

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -3,6 +3,7 @@ const { promisify } = require('util');
 const path = require('path');
 const fs = require('fs');
 const gettextParser = require('..');
+const { normalizeParseArgs, normalizeStreamArgs } = require('../lib/poparser');
 
 const readFile = promisify(fs.readFile);
 
@@ -10,6 +11,76 @@ const expect = chai.expect;
 chai.config.includeStack = true;
 
 describe('PO Parser', () => {
+  describe('normalizeParseArgs', () => {
+    [
+      {
+        input: ['foo'],
+        expected: { buffer: 'foo', defaultCharset: undefined, validation: undefined }
+      },
+      {
+        input: ['foo', 'bar'],
+        expected: { buffer: 'foo', defaultCharset: 'bar' }
+      },
+      {
+        input: ['foo', { defaultCharset: 'bar' }],
+        expected: { buffer: 'foo', defaultCharset: 'bar', validation: undefined }
+      },
+      {
+        input: ['foo', { validation: true }],
+        expected: { buffer: 'foo', defaultCharset: undefined, validation: true }
+      },
+      {
+        input: ['foo', { defaultCharset: 'bar', validation: true }],
+        expected: { buffer: 'foo', defaultCharset: 'bar', validation: true }
+      }
+    ].forEach(({ input, expected }) => {
+      it(`should return normalized arguments for argument list of ${JSON.stringify(input)}`, () => {
+        expect(normalizeParseArgs(...input)).to.deep.equal(expected);
+      });
+    });
+  });
+
+  describe('normalizeStreamArgs', () => {
+    [
+      {
+        input: [],
+        expected: { transformOptions: {} }
+      },
+      {
+        input: ['foo'],
+        expected: { defaultCharset: 'foo', transformOptions: {} }
+      },
+      {
+        input: ['foo', { initialTreshold: 123 }],
+        expected: { defaultCharset: 'foo', transformOptions: { initialTreshold: 123 } }
+      },
+      {
+        input: [{ initialTreshold: 123 }],
+        expected: { transformOptions: { initialTreshold: 123 } }
+      },
+      {
+        input: [{ validation: true }],
+        expected: { defaultCharset: undefined, validation: true, transformOptions: {} }
+      },
+      {
+        input: [{ defaultCharset: 'foo' }],
+        expected: { defaultCharset: 'foo', validation: undefined, transformOptions: {} }
+      },
+      {
+        input: [{ defaultCharset: 'foo', validation: true }],
+        expected: { defaultCharset: 'foo', validation: true, transformOptions: {} }
+      },
+      {
+        input: [{ defaultCharset: 'foo', validation: true }, { initialTreshold: 123 }],
+        expected: { defaultCharset: 'foo', validation: true, transformOptions: { initialTreshold: 123 } }
+      }
+    ].forEach(({ input, expected }) => {
+      it(`should return normalized arguments for argument list of ${JSON.stringify(input)}`, () => {
+        expect(normalizeStreamArgs(...input)).to.deep.equal(expected);
+      });
+    });
+  });
+
   describe('headers', () => {
     it('should detect charset in header', async () => {
       const [po, json] = await Promise.all([
@@ -117,106 +188,106 @@ describe('PO Parser', () => {
     });
 
     describe('when validation is disabled', () => {
-      const validation = false;
+      const options = { validation: false };
 
       it('should throw (unescaped quote)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/error-unescaped-quote.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw(invalidKeyError);
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw(invalidKeyError);
       });
 
       it('should throw (double-escaped quote)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/error-double-escaped-quote.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw(invalidKeyError);
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw(invalidKeyError);
       });
 
       it('should not throw (an entry has too few plural forms)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-too-few-plural-forms.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.not.throw();
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.not.throw();
       });
 
       it('should not throw (an entry has too many plural forms)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-too-many-plural-forms.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.not.throw();
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.not.throw();
       });
 
       it('should not throw (an entry misses "msgid_plural")', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgid-plural.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.not.throw();
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.not.throw();
       });
 
       it('should not throw (an entry misses single "msgstr")', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgstr.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.not.throw();
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.not.throw();
       });
 
       it('should not throw (duplicate entries found in the same context)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-context-duplicate-entries.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.not.throw();
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.not.throw();
       });
 
       it('should not throw (an entry with multiple "msgid_plural")', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-redundant-msgid-plural.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.not.throw();
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.not.throw();
       });
     });
 
     describe('when validation is enabled', () => {
-      const validation = true;
+      const options = { validation: true };
 
       it('should throw (unescaped quote)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/error-unescaped-quote.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw(invalidKeyError);
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw(invalidKeyError);
       });
 
       it('should throw (double-escaped quote)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/error-double-escaped-quote.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw(invalidKeyError);
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw(invalidKeyError);
       });
 
       it('should throw (an entry has too few plural forms)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-too-few-plural-forms.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw('Plural forms range error: Expected to find 3 forms but got 2 for entry "o1-2" in "" context.');
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw('Plural forms range error: Expected to find 3 forms but got 2 for entry "o1-2" in "" context.');
       });
 
       it('should throw (an entry has too many plural forms)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-too-many-plural-forms.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw('Plural forms range error: Expected to find 2 forms but got 3 for entry "o1-2" in "" context.');
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw('Plural forms range error: Expected to find 2 forms but got 3 for entry "o1-2" in "" context.');
       });
 
       it('should throw (an entry misses "msgid_plural")', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgid-plural.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw('Translation string range error: Extected 1 msgstr definitions associated with "o1-1" in "" context, found 2.');
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw('Translation string range error: Extected 1 msgstr definitions associated with "o1-1" in "" context, found 2.');
       });
 
       it('should throw (an entry misses single "msgstr")', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-missing-msgstr.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw('Translation string range error: Extected 1 msgstr definitions associated with "o1" in "" context, found 0.');
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw('Translation string range error: Extected 1 msgstr definitions associated with "o1" in "" context, found 0.');
       });
 
       it('should throw (duplicate entries found in the same context)', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-context-duplicate-entries.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw('Duplicate msgid error: entry "o1-1" in "c2" context has already been declared.');
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw('Duplicate msgid error: entry "o1-1" in "c2" context has already been declared.');
       });
 
       it('should throw (an entry with multiple "msgid_plural")', async () => {
         const po = await readFile(path.join(__dirname, 'fixtures/validate-redundant-msgid-plural.po'));
 
-        expect(gettextParser.po.parse.bind(gettextParser.po, po, validation)).to.throw('Multiple msgid_plural error: entry "o1-1" in "" context has multiple msgid_plural declarations.');
+        expect(gettextParser.po.parse.bind(gettextParser.po, po, options)).to.throw('Multiple msgid_plural error: entry "o1-1" in "" context has multiple msgid_plural declarations.');
       });
     });
   });

--- a/test/shared.js
+++ b/test/shared.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const { promisify } = require('util');
 const path = require('path');
-const { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely } = require('../lib/shared');
+const { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely, unshiftOptionalArgs } = require('../lib/shared');
 const readFile = promisify(require('fs').readFile);
 
 const expect = chai.expect;
@@ -192,6 +192,64 @@ X-Poedit-SourceCharset: UTF-8`;
       const nplurals = parseNPluralFromHeadersSafely(headers);
 
       expect(nplurals).to.equal(1);
+    });
+  });
+
+  describe('unshiftOptionalArgs', () => {
+    it('should redistribute optional argument list - all arguments are present', () => {
+      const types = ['number', 'boolean', 'string'];
+      const args = [0, false, 'foo'];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([...args]);
+    });
+
+    it('should redistribute optional argument list - all arguments are missing', () => {
+      const types = ['number', 'boolean', 'string'];
+      const args = [];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([undefined, undefined, undefined]);
+    });
+
+    it('should redistribute optional argument list - missing first argument', () => {
+      const types = ['number', 'boolean', 'string'];
+      const args = [false, 'foo'];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([undefined, false, 'foo']);
+    });
+
+    it('should redistribute optional argument list - missing last argument', () => {
+      const types = ['number', 'boolean', 'string'];
+      const args = [0, false];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([0, false, undefined]);
+    });
+
+    it('should redistribute optional argument list - missing intermediate argument', () => {
+      const types = ['number', 'boolean', 'string'];
+      const args = [0, 'foo'];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([0, undefined, 'foo']);
+    });
+
+    it('should redistribute optional argument list - two concequtive argments are of the same type, first argument is undefined', () => {
+      const types = ['boolean', 'boolean'];
+      const args = [undefined, false];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([undefined, false]);
+    });
+
+    it('should redistribute optional argument list - two concequtive argments are of the same type, second argument is undefined', () => {
+      const types = ['boolean', 'boolean'];
+      const args = [false];
+      const actual = unshiftOptionalArgs(types, args);
+
+      expect(actual).to.deep.equal([false, undefined]);
     });
   });
 });

--- a/test/shared.js
+++ b/test/shared.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const { promisify } = require('util');
 const path = require('path');
-const { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely, unshiftOptionalArgs } = require('../lib/shared');
+const { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely } = require('../lib/shared');
 const readFile = promisify(require('fs').readFile);
 
 const expect = chai.expect;
@@ -192,64 +192,6 @@ X-Poedit-SourceCharset: UTF-8`;
       const nplurals = parseNPluralFromHeadersSafely(headers);
 
       expect(nplurals).to.equal(1);
-    });
-  });
-
-  describe('unshiftOptionalArgs', () => {
-    it('should redistribute optional argument list - all arguments are present', () => {
-      const types = ['number', 'boolean', 'string'];
-      const args = [0, false, 'foo'];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([...args]);
-    });
-
-    it('should redistribute optional argument list - all arguments are missing', () => {
-      const types = ['number', 'boolean', 'string'];
-      const args = [];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([undefined, undefined, undefined]);
-    });
-
-    it('should redistribute optional argument list - missing first argument', () => {
-      const types = ['number', 'boolean', 'string'];
-      const args = [false, 'foo'];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([undefined, false, 'foo']);
-    });
-
-    it('should redistribute optional argument list - missing last argument', () => {
-      const types = ['number', 'boolean', 'string'];
-      const args = [0, false];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([0, false, undefined]);
-    });
-
-    it('should redistribute optional argument list - missing intermediate argument', () => {
-      const types = ['number', 'boolean', 'string'];
-      const args = [0, 'foo'];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([0, undefined, 'foo']);
-    });
-
-    it('should redistribute optional argument list - two concequtive argments are of the same type, first argument is undefined', () => {
-      const types = ['boolean', 'boolean'];
-      const args = [undefined, false];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([undefined, false]);
-    });
-
-    it('should redistribute optional argument list - two concequtive argments are of the same type, second argument is undefined', () => {
-      const types = ['boolean', 'boolean'];
-      const args = [false];
-      const actual = unshiftOptionalArgs(types, args);
-
-      expect(actual).to.deep.equal([false, undefined]);
     });
   });
 });


### PR DESCRIPTION
The aim of this PR is to introduce validation rules for PO parsing logic. Those rules check that:

- there is exactly zero or one `msgid_plural` definition per translation entry; a `Multiple msgid_plural error` error gets thrown otherwise.
- there are no duplicate entries with exact `msgid` values; a `Duplicate msgid error` error gets thrown otherwise.
- the number of plural forms matches exactly the number from `nplurals` defined in `Plural-Forms` header for entries that have plural forms; a `Plural forms range error` error gets thrown otherwise.
- the number of `msgstr` matches exacty the one (if `msgid_plural` is not defined) or the number from `nplurals` (if `msgid_plural` is defined); a `Translation string range error` error gets thrown otherwise.