### PR TITLE
perf(parseComments): optimize string allocations in _parseComments

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -260,48 +260,57 @@ Parser.prototype._joinStringValues = function (tokens) {
 Parser.prototype._parseComments = function (tokens) {
   // parse comments
   tokens.forEach(node => {
-    let comment;
-    let lines;
+    if(!node || !node.value || node.type !== this.types.comments) return
 
-    if (node && node.type === this.types.comments) {
-      comment = {
-        translator: [],
-        extracted: [],
-        reference: [],
-        flag: [],
-        previous: []
-      };
+    const comment = {
+      translator: "",
+      extracted: "",
+      reference: "",
+      flag: "",
+      previous: ""
+    };
 
-      lines = (node.value || '').split(/\n/);
+    const lines = node.value.split(/\n/);
 
-      lines.forEach(line => {
-        switch (line.charAt(0) || '') {
-          case ':':
-            comment.reference.push(line.substr(1).trim());
-            break;
-          case '.':
-            comment.extracted.push(line.substr(1).replace(/^\s+/, ''));
-            break;
-          case ',':
-            comment.flag.push(line.substr(1).replace(/^\s+/, ''));
-            break;
-          case '|':
-            comment.previous.push(line.substr(1).replace(/^\s+/, ''));
-            break;
-          case '~':
-            break;
-          default:
-            comment.translator.push(line.replace(/^\s+/, ''));
-        }
-      });
+    lines.forEach(line => {
+      if(!line.length) return
 
-      node.value = {};
+      switch (line[0]) {
+        case ':':
+          comment.reference = (comment.reference ? comment.reference + "\n" : "") + line.replace(/^:\s+/, '');
+          break;
+        case '.':
+          comment.extracted = (comment.extracted ? comment.extracted + "\n" : "") + line.replace(/^\.\s+/, '');
+          break;
+        case ',':
+          comment.flag = (comment.flag ? comment.flag + "\n" : "") + line.replace(/^\,\s+/, '');
+          break;
+        case '|':
+          comment.previous = (comment.previous ? comment.previous + "\n" : "") + line.replace(/^\|\s+/, '');
+          break;
+        case '~':
+          break;
+        default:
+          comment.translator = (comment.translator ? comment.translator + "\n" : "") + line.replace(/^\s+/, '');
+      }
+    });
 
-      Object.keys(comment).forEach(key => {
-        if (comment[key] && comment[key].length) {
-          node.value[key] = comment[key].join('\n');
-        }
-      });
+    node.value = {};
+
+    if(comment['translator']) {
+      node.value['translator'] = comment['translator'];
+    }
+    if(comment['extracted']) {
+      node.value['extracted'] = comment['extracted'];
+    }
+    if(comment['reference']) {
+      node.value['reference'] = comment['reference'];
+    }
+    if(comment['flag']) {
+      node.value['flag'] = comment['flag'];
+    }
+    if(comment['previous']) {
+      node.value['previous'] = comment['previous'];
     }
   });
 };


### PR DESCRIPTION
First of all, thanks for the great project, we use it at Sentry via our [po-catalog-loader](https://github.com/getsentry/po-catalog-loader#readme).

We recently started profiling our webpack build processes and noticed that compared to regular parsing of the files, a significant amount of time was spent in the _parseComments fn (all of the red colored frames are calls to _parseComments fn)
<img width="764" alt="CleanShot 2023-03-22 at 21 48 58@2x" src="https://user-images.githubusercontent.com/9317857/227078303-1b9a5322-abe7-4457-a2f1-0a8e6d4ca4af.png">

At a quick glance, I suspect that this is due to the amount of string allocations being made - full transparency, I have not benchmarked any of this but would be happy to it if it makes for a stronger case for the changes in this PR.

changes:
- instead of pushing to array and joining the values in the end, append the strings directly
- since keys are known in advance, hardcode them instead of call Object.keys
- merge the substring and regexp replace into a single replace call
- return earlier from the token loop

