### PR TITLE
Update deprecated substr and slice methods to their modern equivalents

### DIFF
--- a/lib/moparser.js
+++ b/lib/moparser.js
@@ -87,14 +87,20 @@ Parser.prototype._loadTranslationTable = function () {
     offsetOriginals += 4;
     position = this._fileContents[this._readFunc](offsetOriginals);
     offsetOriginals += 4;
-    msgid = this._fileContents.slice(position, position + length);
+    msgid = this._fileContents.subarray(
+      position,
+      position + length,
+    );
 
     // matching msgstr
     length = this._fileContents[this._readFunc](offsetTranslations);
     offsetTranslations += 4;
     position = this._fileContents[this._readFunc](offsetTranslations);
     offsetTranslations += 4;
-    msgstr = this._fileContents.slice(position, position + length);
+    msgstr = this._fileContents.subarray(
+      position,
+      position + length,
+    );
 
     if (!i && !msgid.toString()) {
       this._handleCharset(msgstr);

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -77,8 +77,8 @@ Parser.prototype._handleCharset = function (buf = '') {
   let match;
 
   if ((pos = str.search(/^\s*msgid/im)) >= 0) {
-    pos = pos + str.substr(pos + 5).search(/^\s*(msgid|msgctxt)/im);
-    headers = str.substr(0, pos >= 0 ? pos + 5 : str.length);
+    pos = pos + str.substring(pos + 5).search(/^\s*(msgid|msgctxt)/im);
+    headers = str.substring(0, pos >= 0 ? pos + 5 : str.length);
   }
 
   if ((match = headers.match(/[; ]charset\s*=\s*([\w-]+)(?:[\s;]|\\n)*"\s*$/mi))) {
@@ -279,16 +279,16 @@ Parser.prototype._parseComments = function (tokens) {
     lines.forEach(line => {
       switch (line.charAt(0) || '') {
         case ':':
-          comment.reference.push(line.substr(1).trim());
+          comment.reference.push(line.substring(1).trim());
           break;
         case '.':
-          comment.extracted.push(line.substr(1).replace(/^\s+/, ''));
+          comment.extracted.push(line.substring(1).replace(/^\s+/, ''));
           break;
         case ',':
-          comment.flag.push(line.substr(1).replace(/^\s+/, ''));
+          comment.flag.push(line.substring(1).replace(/^\s+/, ''));
           break;
         case '|':
-          comment.previous.push(line.substr(1).replace(/^\s+/, ''));
+          comment.previous.push(line.substring(1).replace(/^\s+/, ''));
           break;
         case '~':
           break;
@@ -392,7 +392,7 @@ Parser.prototype._handleValues = function (tokens) {
 
       curContext = false;
       curComments = false;
-    } else if (tokens[i].key.substr(0, 6).toLowerCase() === 'msgstr') {
+    } else if (tokens[i].key.substring(0, 6).toLowerCase() === 'msgstr') {
       if (lastNode) {
         lastNode.msgstr = (lastNode.msgstr || []).concat(tokens[i].value);
       }


### PR DESCRIPTION
This PR updates the usage of deprecated substr and slice methods to their modern equivalents, substring and subarray, respectively. These changes aim to enhance the codebase by adopting up-to-date standards and practices without introducing any drawbacks.