### PR TITLE
Removes safe-buffer (not needed anymore)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   "dependencies": {
     "content-type": "^1.0.5",
     "encoding": "^0.1.13",
-    "readable-stream": "^4.5.2",
-    "safe-buffer": "^5.2.1"
+    "readable-stream": "^4.5.2"
   },
   "devDependencies": {
     "@types/chai": "latest",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,5 @@
 import { Transform } from "readable-stream";
 
-import {Buffer} from "safe-buffer";
-
 export declare module 'encoding' {
     export function convert(buf: Buffer, toCharset: string, fromCharset: string): Buffer;
 }

--- a/src/mocompiler.js
+++ b/src/mocompiler.js
@@ -1,4 +1,3 @@
-import { Buffer } from 'safe-buffer';
 import encoding from 'encoding';
 import { HEADERS, formatCharset, generateHeader, compareMsgid } from './shared.js';
 import contentType from 'content-type';

--- a/src/pocompiler.js
+++ b/src/pocompiler.js
@@ -1,4 +1,3 @@
-import { Buffer } from 'safe-buffer';
 import encoding from 'encoding';
 import { HEADERS, foldLine, compareMsgid, formatCharset, generateHeader } from './shared.js';
 import contentType from 'content-type';


### PR DESCRIPTION
Buffer has been included in the node library since 5.1 and at the moment, since our minimum node version is the 18, we don't need it anymore

https://nodejs.org/api/buffer.html#static-method-bufferallocsize-fill-encoding