### PR TITLE
speed up lexer parsing

### DIFF
--- a/src/poparser.js
+++ b/src/poparser.js
@@ -146,7 +146,7 @@ Parser.prototype._lexer = function (chunk) {
     switch (this._state) {
       case this.states.none:
       case this.states.obsolete:
-        if (chr.match(this.symbols.quotes)) {
+        if (chr === '"' || chr === "'") {
           this._node = {
             type: this.types.string,
             value: '',
@@ -154,7 +154,7 @@ Parser.prototype._lexer = function (chunk) {
           };
           this._lex.push(this._node);
           this._state = this.states.string;
-        } else if (chr.match(this.symbols.comments)) {
+        } else if (chr === "#") {
           this._node = {
             type: this.types.comments,
             value: ''

--- a/src/poparser.js
+++ b/src/poparser.js
@@ -121,8 +121,6 @@ Parser.prototype.types = {
  * String matches for lexer
  */
 Parser.prototype.symbols = {
-  quotes: /["']/,
-  comments: /#/,
   whitespace: /\s/,
   key: /[\w\-[\]]/,
   keyNames: /^(?:msgctxt|msgid(?:_plural)?|msgstr(?:\[\d+])?)$/


### PR DESCRIPTION
During the lexer parsing there are 2 cases that didn't require a regex (that is heavily costly compared to a chr/string comparison). 

This small change provides an speed increased of about 20-25%. 

Tested with [benny](https://www.npmjs.com/package/benny)
```
Running "Example" suite...
Progress: 100%

  gettextParser:
    6 631 ops/s, ±0.63%   | slowest, 23.54% slower

  gettextParserNext:
    8 673 ops/s, ±0.42%   | fastest

Finished 2 cases!
  Fastest: gettextParserNext
  Slowest: gettextParser
```