### PR TITLE
Fixes missing replacements for deprecated code

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha",
     "preversion": "npm run lint && npm test",
     "postversion": "git push && git push --tags",
-    "prepublish": "tsc && npm run lint && npm run test"
+    "prepublishOnly": "npm i && tsc && npm run lint && npm run test"
   },
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/poparser.js
+++ b/src/poparser.js
@@ -579,9 +579,9 @@ PoParserTransform.prototype._transform = function (chunk, encoding, done) {
   }
   // it seems we found some 8bit bytes from the end of the string, so let's cache these
   if (len) {
-    this._cache = [chunk.slice(chunk.length - len)];
+    this._cache = [chunk.subarray(chunk.length - len)];
     this._cacheSize = this._cache[0].length;
-    chunk = chunk.slice(0, chunk.length - len);
+    chunk = chunk.subarray(0, chunk.length - len);
   }
 
   // chunk might be empty if it only continued of 8bit bytes and these were all cached

--- a/src/shared.js
+++ b/src/shared.js
@@ -111,11 +111,11 @@ export function foldLine (str, maxLen = 76) {
   let match;
 
   while (pos < len) {
-    curLine = str.substr(pos, maxLen);
+    curLine = str.substring(pos, pos + maxLen);
 
     // ensure that the line never ends with a partial escaping
     // make longer lines if needed
-    while (curLine.substr(-1) === '\\' && pos + curLine.length < len) {
+    while (curLine.substring(-1) === '\\' && pos + curLine.length < len) {
       curLine += str.charAt(pos + curLine.length);
     }
 


### PR DESCRIPTION
(chore)

- in shared.js i forgot to replace some deprecated code

- scripts - make sure that all is ready before fire the "prepublish" script and fire that script ONLY on prepublish (otherwise it was fired also after the install)