### PR TITLE
refactor: fix usage of deprecated APIs

### DIFF
--- a/lib/moparser.js
+++ b/lib/moparser.js
@@ -87,14 +87,20 @@ Parser.prototype._loadTranslationTable = function () {
     offsetOriginals += 4;
     position = this._fileContents[this._readFunc](offsetOriginals);
     offsetOriginals += 4;
-    msgid = this._fileContents.slice(position, position + length);
+    msgid = this._fileContents.subarray(
+      position,
+      position + length
+    );
 
     // matching msgstr
     length = this._fileContents[this._readFunc](offsetTranslations);
     offsetTranslations += 4;
     position = this._fileContents[this._readFunc](offsetTranslations);
     offsetTranslations += 4;
-    msgstr = this._fileContents.slice(position, position + length);
+    msgstr = this._fileContents.subarray(
+      position,
+      position + length
+    );
 
     if (!i && !msgid.toString()) {
       this._handleCharset(msgstr);

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -19,7 +19,7 @@ export function parse (input, options = {}) {
 /**
  * Parses a PO stream, emits translation table in object mode
  *
- * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
+ * @typedef {{ defaultCharset: string, validation: boolean }} Options
  * @param {Options} [options] Optional options with defaultCharset and validation
  * @param {import('readable-stream').TransformOptions} [transformOptions] Optional stream options
  */
@@ -77,8 +77,8 @@ Parser.prototype._handleCharset = function (buf = '') {
   let match;
 
   if ((pos = str.search(/^\s*msgid/im)) >= 0) {
-    pos = pos + str.substr(pos + 5).search(/^\s*(msgid|msgctxt)/im);
-    headers = str.substr(0, pos >= 0 ? pos + 5 : str.length);
+    pos = pos + str.substring(pos + 5).search(/^\s*(msgid|msgctxt)/im);
+    headers = str.substring(0, pos >= 0 ? pos + 5 : str.length);
   }
 
   if ((match = headers.match(/[; ]charset\s*=\s*([\w-]+)(?:[\s;]|\\n)*"\s*$/mi))) {
@@ -121,8 +121,6 @@ Parser.prototype.types = {
  * String matches for lexer
  */
 Parser.prototype.symbols = {
-  quotes: /["']/,
-  comments: /#/,
   whitespace: /\s/,
   key: /[\w\-[\]]/,
   keyNames: /^(?:msgctxt|msgid(?:_plural)?|msgstr(?:\[\d+])?)$/
@@ -146,7 +144,7 @@ Parser.prototype._lexer = function (chunk) {
     switch (this._state) {
       case this.states.none:
       case this.states.obsolete:
-        if (chr.match(this.symbols.quotes)) {
+        if (chr === '"' || chr === "'") {
           this._node = {
             type: this.types.string,
             value: '',
@@ -154,7 +152,7 @@ Parser.prototype._lexer = function (chunk) {
           };
           this._lex.push(this._node);
           this._state = this.states.string;
-        } else if (chr.match(this.symbols.comments)) {
+        } else if (chr === '#') {
           this._node = {
             type: this.types.comments,
             value: ''
@@ -279,16 +277,16 @@ Parser.prototype._parseComments = function (tokens) {
     lines.forEach(line => {
       switch (line.charAt(0) || '') {
         case ':':
-          comment.reference.push(line.substr(1).trim());
+          comment.reference.push(line.substring(1).trim());
           break;
         case '.':
-          comment.extracted.push(line.substr(1).replace(/^\s+/, ''));
+          comment.extracted.push(line.substring(1).replace(/^\s+/, ''));
           break;
         case ',':
-          comment.flag.push(line.substr(1).replace(/^\s+/, ''));
+          comment.flag.push(line.substring(1).replace(/^\s+/, ''));
           break;
         case '|':
-          comment.previous.push(line.substr(1).replace(/^\s+/, ''));
+          comment.previous.push(line.substring(1).replace(/^\s+/, ''));
           break;
         case '~':
           break;
@@ -392,7 +390,7 @@ Parser.prototype._handleValues = function (tokens) {
 
       curContext = false;
       curComments = false;
-    } else if (tokens[i].key.substr(0, 6).toLowerCase() === 'msgstr') {
+    } else if (tokens[i].key.substring(0, 6).toLowerCase() === 'msgstr') {
       if (lastNode) {
         lastNode.msgstr = (lastNode.msgstr || []).concat(tokens[i].value);
       }
@@ -515,7 +513,7 @@ Parser.prototype._finalize = function (tokens) {
 /**
  * Creates a transform stream for parsing PO input
  *
- * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
+ * @typedef {{ defaultCharset: string, validation: boolean }} Options
  * @constructor
  * @param {Options} options Optional options with defaultCharset and validation
  * @param {import('readable-stream').TransformOptions} transformOptions Optional stream options
@@ -581,9 +579,9 @@ PoParserTransform.prototype._transform = function (chunk, encoding, done) {
   }
   // it seems we found some 8bit bytes from the end of the string, so let's cache these
   if (len) {
-    this._cache = [chunk.slice(chunk.length - len)];
+    this._cache = [chunk.subarray(chunk.length - len)];
     this._cacheSize = this._cache[0].length;
-    chunk = chunk.slice(0, chunk.length - len);
+    chunk = chunk.subarray(0, chunk.length - len);
   }
 
   // chunk might be empty if it only continued of 8bit bytes and these were all cached

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -46,7 +46,7 @@ export function parseHeader (str = '') {
  * @returns {number} Parsed result
  */
 export function parseNPluralFromHeadersSafely (headers = {}, fallback = 1) {
-  const pluralForms = headers[PLURAL_FORMS];
+  const pluralForms = headers?.[PLURAL_FORMS];
 
   if (!pluralForms) {
     return fallback;
@@ -99,9 +99,9 @@ export function formatCharset (charset = 'iso-8859-1', defaultCharset = 'iso-885
 /**
  * Folds long lines according to PO format
  *
- * @param {String} str PO formatted string to be folded
- * @param {Number} [maxLen=76] Maximum allowed length for folded lines
- * @return {Array} An array of lines
+ * @param {string} str PO formatted string to be folded
+ * @param {number} [maxLen=76] Maximum allowed length for folded lines
+ * @return {string[]} An array of lines
  */
 export function foldLine (str, maxLen = 76) {
   const lines = [];
@@ -111,11 +111,11 @@ export function foldLine (str, maxLen = 76) {
   let match;
 
   while (pos < len) {
-    curLine = str.substr(pos, maxLen);
+    curLine = str.substring(pos, pos + maxLen);
 
     // ensure that the line never ends with a partial escaping
     // make longer lines if needed
-    while (curLine.substr(-1) === '\\' && pos + curLine.length < len) {
+    while (curLine.substring(-1) === '\\' && pos + curLine.length < len) {
       curLine += str.charAt(pos + curLine.length);
     }
 


### PR DESCRIPTION
This commit fixes the usage of deprecated APIs in the codebase. Specifically, usages of the following:

- `Buffer.slice` has been replaced with `Buffer.subarray`
- `substr` has been replaced with `substring`

This commit also does the following:

- Fixes a few typos in the JSDoc comments.
- Replaces PO parsing regex matches for quotes and comments with conditional string matching.