### PR TITLE
Track coverage using C8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm test
+      - run: npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint src/*.js test/*.js",
     "test-generate-mo": "msgfmt test/fixtures/latin13.po -o test/fixtures/latin13.mo & msgfmt test/fixtures/utf8.po -o test/fixtures/utf8.mo & msgfmt test/fixtures/obsolete.po -o test/fixtures/obsolete.mo",
     "test": "mocha",
+    "test:coverage": "npx c8 --check-coverage npm run test",
     "preversion": "npm run lint && npm test",
     "postversion": "git push && git push --tags",
     "prepublish": "tsc && npm run lint && npm run test"
@@ -46,7 +47,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
-    "mocha": "^10.3.0",
+    "mocha": "^10.4.0",
     "typescript": "^5.4.5"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:coverage": "npx c8 --check-coverage npm run test",
     "preversion": "npm run lint && npm test",
     "postversion": "git push && git push --tags",
-    "prepublish": "tsc && npm run lint && npm run test"
+    "prepublishOnly": "tsc && npm run lint && npm run test"
   },
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
This PR adds the coverage for tests

long story short, since the most used with mocha is nyc I thought it would work whereas since it is esm you have to use c8

https://github.com/istanbuljs/nyc/issues/1287#issuecomment-706527909