### PR TITLE
Provides full coverage for shared functions (shared.js)

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -121,8 +121,8 @@ export function foldLine (str, maxLen = 76) {
 
     // ensure that the line never ends with a partial escaping
     // make longer lines if needed
-    while (curLine.substring(-1) === '\\' && pos + curLine.length < len) {
-      curLine += str.charAt(pos + curLine.length);
+    while (curLine.endsWith('\\') && pos + curLine.length < len) {
+      curLine += str.charAt(pos + curLine.length + 1); // Append the next character
     }
 
     // ensure that if possible, line breaks are done at reasonable places

--- a/test/shared.js
+++ b/test/shared.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { readFile as fsReadFile } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import * as chai from 'chai';
-import { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely } from '../src/shared.js';
+import { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely, compareMsgid } from '../src/shared.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -87,6 +87,17 @@ X-Poedit-SourceCharset: UTF-8`;
       expect(line).to.equal(folded.join(''));
       expect(folded).to.deep.equal(['abc \\n', 'def \\n', 'ghi']);
       expect(folded.length).to.equal(3);
+    });
+
+    it('should ensure that the line never ends with a partial escaping', () => {
+      const line = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\'aaaaa\'aaaa';
+      const folded = foldLine(line);
+
+      expect(line).to.equal(folded.join(''));
+      expect(folded).to.deep.equal([
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'",
+        "aaaaa'aaaa"
+      ]);
     });
 
     it('should fold at default length', () => {
@@ -197,5 +208,22 @@ X-Poedit-SourceCharset: UTF-8`;
 
       expect(nplurals).to.equal(1);
     });
+  });
+});
+
+describe('Strings Sorting function', () => {
+  it('should return -1 when left msgid is less than right msgid', () => {
+    const result = compareMsgid({ msgid: 'a' }, { msgid: 'b' });
+    expect(result).to.equal(-1);
+  });
+
+  it('should return 1 when left msgid is greater than right msgid', () => {
+    const result = compareMsgid({ msgid: 'b' }, { msgid: 'a' });
+    expect(result).to.equal(1);
+  });
+
+  it('should return 0 when left msgid is equal to right msgid', () => {
+    const result = compareMsgid({ msgid: 'a' }, { msgid: 'a' });
+    expect(result).to.equal(0);
   });
 });


### PR DESCRIPTION
Covers 'shared' functions with tests 

@johnhooks can you take a look at this? I tested the result with the original function, and with the current updated code and it seems there are some issues, and this condition cannot be verified:
https://github.com/smhg/gettext-parser/blob/d8dcbee79324b3fffbfa8b56dd51abf8da484904/lib/shared.js#L116-L120

Precisely in this row (from the original shared.js before any modification):
 `while (curLine.substr(-1) === '\\' && pos + curLine.length < len) {`

It was intended `\\\\` and not `\\`?

