### PR TITLE
Remove safe-buffer as methods are supported from minimum required Node.js 18

### DIFF
--- a/lib/mocompiler.js
+++ b/lib/mocompiler.js
@@ -1,4 +1,4 @@
-import { Buffer } from 'safe-buffer';
+import { Buffer } from 'node:buffer';
 import encoding from 'encoding';
 import { HEADERS, formatCharset, generateHeader, compareMsgid } from './shared.js';
 import contentType from 'content-type';

--- a/lib/pocompiler.js
+++ b/lib/pocompiler.js
@@ -1,4 +1,4 @@
-import { Buffer } from 'safe-buffer';
+import { Buffer } from 'node:buffer';
 import encoding from 'encoding';
 import { HEADERS, foldLine, compareMsgid, formatCharset, generateHeader } from './shared.js';
 import contentType from 'content-type';

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "content-type": "^1.0.5",
     "encoding": "^0.1.13",
-    "readable-stream": "^4.5.2",
-    "safe-buffer": "^5.2.1"
+    "readable-stream": "^4.5.2"
   },
   "devDependencies": {
     "chai": "^5.0.3",


### PR DESCRIPTION
https://nodejs.org/docs/latest-v18.x/api/buffer.html