### PR TITLE
feat: use ES6 classes

### DIFF
--- a/lib/mocompiler.js
+++ b/lib/mocompiler.js
@@ -1,6 +1,11 @@
 import { Buffer } from 'node:buffer';
 import encoding from 'encoding';
-import { HEADERS, formatCharset, generateHeader, compareMsgid } from './shared.js';
+import {
+  HEADERS,
+  formatCharset,
+  generateHeader,
+  compareMsgid
+} from './shared.js';
 import contentType from 'content-type';
 
 /**
@@ -14,238 +19,256 @@ export default function (table) {
   const compiler = new Compiler(table);
 
   return compiler.compile();
-};
+}
 
 /**
  * Creates a MO compiler object.
- *
- * @constructor
- * @param {Object} table Translation table as defined in the README
  */
-function Compiler (table = {}) {
-  this._table = table;
+class Compiler {
+  constructor (table = {}) {
+    this._table = table;
 
-  let { headers = {}, translations = {} } = this._table;
+    let { headers = {}, translations = {} } = this._table;
 
-  headers = Object.keys(headers).reduce((result, key) => {
-    const lowerKey = key.toLowerCase();
+    headers = Object.keys(headers).reduce((result, key) => {
+      const lowerKey = key.toLowerCase();
 
-    if (HEADERS.has(lowerKey)) {
-      // POT-Creation-Date is removed in MO (see https://savannah.gnu.org/bugs/?49654)
-      if (lowerKey !== 'pot-creation-date') {
-        result[HEADERS.get(lowerKey)] = headers[key];
-      }
-    } else {
-      result[key] = headers[key];
-    }
-
-    return result;
-  }, {});
-
-  // filter out empty translations
-  translations = Object.keys(translations).reduce((result, msgctxt) => {
-    const context = translations[msgctxt];
-    const msgs = Object.keys(context).reduce((result, msgid) => {
-      const hasTranslation = context[msgid].msgstr.some(item => !!item.length);
-
-      if (hasTranslation) {
-        result[msgid] = context[msgid];
+      if (HEADERS.has(lowerKey)) {
+        // POT-Creation-Date is removed in MO (see https://savannah.gnu.org/bugs/?49654)
+        if (lowerKey !== 'pot-creation-date') {
+          result[HEADERS.get(lowerKey)] = headers[key];
+        }
+      } else {
+        result[key] = headers[key];
       }
 
       return result;
     }, {});
 
-    if (Object.keys(msgs).length) {
-      result[msgctxt] = msgs;
-    }
+    // filter out empty translations
+    translations = Object.keys(translations).reduce((result, msgctxt) => {
+      const context = translations[msgctxt];
+      const msgs = Object.keys(context).reduce((result, msgid) => {
+        const hasTranslation = context[msgid].msgstr.some(
+          (item) => !!item.length
+        );
 
-    return result;
-  }, {});
+        if (hasTranslation) {
+          result[msgid] = context[msgid];
+        }
 
-  this._table.translations = translations;
-  this._table.headers = headers;
+        return result;
+      }, {});
 
-  this._translations = [];
+      if (Object.keys(msgs).length) {
+        result[msgctxt] = msgs;
+      }
 
-  this._writeFunc = 'writeUInt32LE';
+      return result;
+    }, {});
 
-  this._handleCharset();
-}
+    this._table.translations = translations;
+    this._table.headers = headers;
 
-/**
- * Magic bytes for the generated binary data
- */
-Compiler.prototype.MAGIC = 0x950412de;
+    this._translations = [];
 
-/**
- * Handles header values, replaces or adds (if needed) a charset property
- */
-Compiler.prototype._handleCharset = function () {
-  const ct = contentType.parse(this._table.headers['Content-Type'] || 'text/plain');
+    this._writeFunc = 'writeUInt32LE';
 
-  const charset = formatCharset(this._table.charset || ct.parameters.charset || 'utf-8');
-
-  // clean up content-type charset independently using fallback if missing
-  if (ct.parameters.charset) {
-    ct.parameters.charset = formatCharset(ct.parameters.charset);
+    this._handleCharset();
   }
 
-  this._table.charset = charset;
-  this._table.headers['Content-Type'] = contentType.format(ct);
-};
+  /**
+   * Magic bytes for the generated binary data
+   */
+  static MAGIC = 0x950412de;
 
-/**
- * Generates an array of translation strings
- * in the form of [{msgid:... , msgstr:...}]
- *
- * @return {Array} Translation strings array
- */
-Compiler.prototype._generateList = function () {
-  const list = [];
+  /**
+   * Handles header values, replaces or adds (if needed) a charset property
+   */
+  _handleCharset () {
+    const ct = contentType.parse(
+      this._table.headers['Content-Type'] || 'text/plain'
+    );
 
-  list.push({
-    msgid: Buffer.alloc(0),
-    msgstr: encoding.convert(generateHeader(this._table.headers), this._table.charset)
-  });
+    const charset = formatCharset(
+      this._table.charset || ct.parameters.charset || 'utf-8'
+    );
 
-  Object.keys(this._table.translations).forEach(msgctxt => {
-    if (typeof this._table.translations[msgctxt] !== 'object') {
-      return;
+    // clean up content-type charset independently using fallback if missing
+    if (ct.parameters.charset) {
+      ct.parameters.charset = formatCharset(ct.parameters.charset);
     }
 
-    Object.keys(this._table.translations[msgctxt]).forEach(msgid => {
-      if (typeof this._table.translations[msgctxt][msgid] !== 'object') {
+    this._table.charset = charset;
+    this._table.headers['Content-Type'] = contentType.format(ct);
+  }
+
+  /**
+   * Generates an array of translation strings
+   * in the form of [{msgid:... , msgstr:...}]
+   *
+   * @return {Array} Translation strings array
+   */
+  _generateList () {
+    const list = [];
+
+    list.push({
+      msgid: Buffer.alloc(0),
+      msgstr: encoding.convert(
+        generateHeader(this._table.headers),
+        this._table.charset
+      )
+    });
+
+    Object.keys(this._table.translations).forEach((msgctxt) => {
+      if (typeof this._table.translations[msgctxt] !== 'object') {
         return;
       }
 
-      if (msgctxt === '' && msgid === '') {
-        return;
-      }
+      Object.keys(this._table.translations[msgctxt]).forEach((msgid) => {
+        if (typeof this._table.translations[msgctxt][msgid] !== 'object') {
+          return;
+        }
 
-      const msgidPlural = this._table.translations[msgctxt][msgid].msgid_plural;
-      let key = msgid;
+        if (msgctxt === '' && msgid === '') {
+          return;
+        }
 
-      if (msgctxt) {
-        key = msgctxt + '\u0004' + key;
-      }
+        const msgidPlural =
+          this._table.translations[msgctxt][msgid].msgid_plural;
+        let key = msgid;
 
-      if (msgidPlural) {
-        key += '\u0000' + msgidPlural;
-      }
+        if (msgctxt) {
+          key = msgctxt + '\u0004' + key;
+        }
 
-      const value = [].concat(this._table.translations[msgctxt][msgid].msgstr || []).join('\u0000');
+        if (msgidPlural) {
+          key += '\u0000' + msgidPlural;
+        }
 
-      list.push({
-        msgid: encoding.convert(key, this._table.charset),
-        msgstr: encoding.convert(value, this._table.charset)
+        const value = []
+          .concat(this._table.translations[msgctxt][msgid].msgstr || [])
+          .join('\u0000');
+
+        list.push({
+          msgid: encoding.convert(key, this._table.charset),
+          msgstr: encoding.convert(value, this._table.charset)
+        });
       });
     });
-  });
 
-  return list;
-};
-
-/**
- * Calculate buffer size for the final binary object
- *
- * @param {Array} list An array of translation strings from _generateList
- * @return {Object} Size data of {msgid, msgstr, total}
- */
-Compiler.prototype._calculateSize = function (list) {
-  let msgidLength = 0;
-  let msgstrLength = 0;
-  let totalLength = 0;
-
-  list.forEach(translation => {
-    msgidLength += translation.msgid.length + 1; // + extra 0x00
-    msgstrLength += translation.msgstr.length + 1; // + extra 0x00
-  });
-
-  totalLength = 4 + // magic number
-        4 + // revision
-        4 + // string count
-        4 + // original string table offset
-        4 + // translation string table offset
-        4 + // hash table size
-        4 + // hash table offset
-        (4 + 4) * list.length + // original string table
-        (4 + 4) * list.length + // translations string table
-        msgidLength + // originals
-        msgstrLength; // translations
-
-  return {
-    msgid: msgidLength,
-    msgstr: msgstrLength,
-    total: totalLength
-  };
-};
-
-/**
- * Generates the binary MO object from the translation list
- *
- * @param {Array} list translation list
- * @param {Object} size Byte size information
- * @return {Buffer} Compiled MO object
- */
-Compiler.prototype._build = function (list, size) {
-  const returnBuffer = Buffer.alloc(size.total);
-  let curPosition = 0;
-  let i;
-  let len;
-
-  // magic
-  returnBuffer[this._writeFunc](this.MAGIC, 0);
-
-  // revision
-  returnBuffer[this._writeFunc](0, 4);
-
-  // string count
-  returnBuffer[this._writeFunc](list.length, 8);
-
-  // original string table offset
-  returnBuffer[this._writeFunc](28, 12);
-
-  // translation string table offset
-  returnBuffer[this._writeFunc](28 + (4 + 4) * list.length, 16);
-
-  // hash table size
-  returnBuffer[this._writeFunc](0, 20);
-
-  // hash table offset
-  returnBuffer[this._writeFunc](28 + (4 + 4) * list.length * 2, 24);
-
-  // build originals table
-  curPosition = 28 + 2 * (4 + 4) * list.length;
-  for (i = 0, len = list.length; i < len; i++) {
-    list[i].msgid.copy(returnBuffer, curPosition);
-    returnBuffer[this._writeFunc](list[i].msgid.length, 28 + i * 8);
-    returnBuffer[this._writeFunc](curPosition, 28 + i * 8 + 4);
-    returnBuffer[curPosition + list[i].msgid.length] = 0x00;
-    curPosition += list[i].msgid.length + 1;
+    return list;
   }
 
-  // build translations table
-  for (i = 0, len = list.length; i < len; i++) {
-    list[i].msgstr.copy(returnBuffer, curPosition);
-    returnBuffer[this._writeFunc](list[i].msgstr.length, 28 + (4 + 4) * list.length + i * 8);
-    returnBuffer[this._writeFunc](curPosition, 28 + (4 + 4) * list.length + i * 8 + 4);
-    returnBuffer[curPosition + list[i].msgstr.length] = 0x00;
-    curPosition += list[i].msgstr.length + 1;
+  /**
+   * Calculate buffer size for the final binary object
+   *
+   * @param {Array} list An array of translation strings from _generateList
+   * @return {Object} Size data of {msgid, msgstr, total}
+   */
+  _calculateSize (list) {
+    let msgidLength = 0;
+    let msgstrLength = 0;
+    let totalLength = 0;
+
+    list.forEach((translation) => {
+      msgidLength += translation.msgid.length + 1; // + extra 0x00
+      msgstrLength += translation.msgstr.length + 1; // + extra 0x00
+    });
+
+    totalLength =
+      4 + // magic number
+      4 + // revision
+      4 + // string count
+      4 + // original string table offset
+      4 + // translation string table offset
+      4 + // hash table size
+      4 + // hash table offset
+      (4 + 4) * list.length + // original string table
+      (4 + 4) * list.length + // translations string table
+      msgidLength + // originals
+      msgstrLength; // translations
+
+    return {
+      msgid: msgidLength,
+      msgstr: msgstrLength,
+      total: totalLength
+    };
   }
 
-  return returnBuffer;
-};
+  /**
+   * Generates the binary MO object from the translation list
+   *
+   * @param {Array} list translation list
+   * @param {Object} size Byte size information
+   * @return {Buffer} Compiled MO object
+   */
+  _build (list, size) {
+    const returnBuffer = Buffer.alloc(size.total);
+    let curPosition = 0;
+    let i;
+    let len;
 
-/**
- * Compiles translation object into a binary MO object
- *
- * @return {Buffer} Compiled MO object
- */
-Compiler.prototype.compile = function () {
-  const list = this._generateList();
-  const size = this._calculateSize(list);
+    // magic
+    returnBuffer[this._writeFunc](Compiler.MAGIC, 0);
 
-  list.sort(compareMsgid);
+    // revision
+    returnBuffer[this._writeFunc](0, 4);
 
-  return this._build(list, size);
-};
+    // string count
+    returnBuffer[this._writeFunc](list.length, 8);
+
+    // original string table offset
+    returnBuffer[this._writeFunc](28, 12);
+
+    // translation string table offset
+    returnBuffer[this._writeFunc](28 + (4 + 4) * list.length, 16);
+
+    // hash table size
+    returnBuffer[this._writeFunc](0, 20);
+
+    // hash table offset
+    returnBuffer[this._writeFunc](28 + (4 + 4) * list.length * 2, 24);
+
+    // build originals table
+    curPosition = 28 + 2 * (4 + 4) * list.length;
+    for (i = 0, len = list.length; i < len; i++) {
+      list[i].msgid.copy(returnBuffer, curPosition);
+      returnBuffer[this._writeFunc](list[i].msgid.length, 28 + i * 8);
+      returnBuffer[this._writeFunc](curPosition, 28 + i * 8 + 4);
+      returnBuffer[curPosition + list[i].msgid.length] = 0x00;
+      curPosition += list[i].msgid.length + 1;
+    }
+
+    // build translations table
+    for (i = 0, len = list.length; i < len; i++) {
+      list[i].msgstr.copy(returnBuffer, curPosition);
+      returnBuffer[this._writeFunc](
+        list[i].msgstr.length,
+        28 + (4 + 4) * list.length + i * 8
+      );
+      returnBuffer[this._writeFunc](
+        curPosition,
+        28 + (4 + 4) * list.length + i * 8 + 4
+      );
+      returnBuffer[curPosition + list[i].msgstr.length] = 0x00;
+      curPosition += list[i].msgstr.length + 1;
+    }
+
+    return returnBuffer;
+  }
+
+  /**
+   * Compiles translation object into a binary MO object
+   *
+   * @return {Buffer} Compiled MO object
+   */
+  compile () {
+    const list = this._generateList();
+    const size = this._calculateSize(list);
+
+    list.sort(compareMsgid);
+
+    return this._build(list, size);
+  }
+}

--- a/lib/moparser.js
+++ b/lib/moparser.js
@@ -12,196 +12,198 @@ export default function (buffer, defaultCharset) {
   const parser = new Parser(buffer, defaultCharset);
 
   return parser.parse();
-};
-
-/**
- * Creates a MO parser object.
- *
- * @constructor
- * @param {Buffer} fileContents Binary MO object
- * @param {String} [defaultCharset] Default charset to use
- */
-function Parser (fileContents, defaultCharset = 'iso-8859-1') {
-  this._fileContents = fileContents;
-
-  /**
-     * Method name for writing int32 values, default littleendian
-     */
-  this._writeFunc = 'writeUInt32LE';
-
-  /**
-     * Method name for reading int32 values, default littleendian
-     */
-  this._readFunc = 'readUInt32LE';
-
-  this._charset = defaultCharset;
-
-  this._table = {
-    charset: this._charset,
-    headers: undefined,
-    translations: {}
-  };
 }
 
 /**
- * Magic constant to check the endianness of the input file
+ * Creates a MO parser object.
  */
-Parser.prototype.MAGIC = 0x950412de;
+class Parser {
+  constructor (fileContents, defaultCharset = 'iso-8859-1') {
+    this._fileContents = fileContents;
 
-/**
- * Checks if number values in the input file are in big- or littleendian format.
- *
- * @return {Boolean} Return true if magic was detected
- */
-Parser.prototype._checkMagick = function () {
-  if (this._fileContents.readUInt32LE(0) === this.MAGIC) {
-    this._readFunc = 'readUInt32LE';
+    /**
+     * Method name for writing int32 values, default littleendian
+     */
     this._writeFunc = 'writeUInt32LE';
 
-    return true;
-  } else if (this._fileContents.readUInt32BE(0) === this.MAGIC) {
-    this._readFunc = 'readUInt32BE';
-    this._writeFunc = 'writeUInt32BE';
+    /**
+     * Method name for reading int32 values, default littleendian
+     */
+    this._readFunc = 'readUInt32LE';
 
-    return true;
+    this._charset = defaultCharset;
+
+    this._table = {
+      charset: this._charset,
+      headers: undefined,
+      translations: {}
+    };
   }
 
-  return false;
-};
+  /**
+   * Magic constant to check the endianness of the input file
+   */
+  static MAGIC = 0x950412de;
 
-/**
- * Read the original strings and translations from the input MO file. Use the
- * first translation string in the file as the header.
- */
-Parser.prototype._loadTranslationTable = function () {
-  let offsetOriginals = this._offsetOriginals;
-  let offsetTranslations = this._offsetTranslations;
-  let position;
-  let length;
-  let msgid;
-  let msgstr;
+  /**
+   * Checks if number values in the input file are in big- or littleendian format.
+   *
+   * @return {Boolean} Return true if magic was detected
+   */
+  _checkMagick () {
+    if (this._fileContents.readUInt32LE(0) === Parser.MAGIC) {
+      this._readFunc = 'readUInt32LE';
+      this._writeFunc = 'writeUInt32LE';
 
-  for (let i = 0; i < this._total; i++) {
-    // msgid string
-    length = this._fileContents[this._readFunc](offsetOriginals);
-    offsetOriginals += 4;
-    position = this._fileContents[this._readFunc](offsetOriginals);
-    offsetOriginals += 4;
-    msgid = this._fileContents.slice(position, position + length);
+      return true;
+    } else if (this._fileContents.readUInt32BE(0) === Parser.MAGIC) {
+      this._readFunc = 'readUInt32BE';
+      this._writeFunc = 'writeUInt32BE';
 
-    // matching msgstr
-    length = this._fileContents[this._readFunc](offsetTranslations);
-    offsetTranslations += 4;
-    position = this._fileContents[this._readFunc](offsetTranslations);
-    offsetTranslations += 4;
-    msgstr = this._fileContents.slice(position, position + length);
-
-    if (!i && !msgid.toString()) {
-      this._handleCharset(msgstr);
+      return true;
     }
 
-    msgid = encoding.convert(msgid, 'utf-8', this._charset)
-      .toString('utf8');
-    msgstr = encoding.convert(msgstr, 'utf-8', this._charset)
-      .toString('utf8');
-
-    this._addString(msgid, msgstr);
-  }
-
-  // dump the file contents object
-  this._fileContents = null;
-};
-
-/**
- * Detects charset for MO strings from the header
- *
- * @param {Buffer} headers Header value
- */
-Parser.prototype._handleCharset = function (headers) {
-  const headersStr = headers.toString();
-  let match;
-
-  if ((match = headersStr.match(/[; ]charset\s*=\s*([\w-]+)/i))) {
-    this._charset = this._table.charset = formatCharset(match[1], this._charset);
-  }
-
-  headers = encoding.convert(headers, 'utf-8', this._charset)
-    .toString('utf8');
-
-  this._table.headers = parseHeader(headers);
-};
-
-/**
- * Adds a translation to the translation object
- *
- * @param {String} msgid Original string
- * @params {String} msgstr Translation for the original string
- */
-Parser.prototype._addString = function (msgid, msgstr) {
-  const translation = {};
-  let msgctxt;
-  let msgidPlural;
-
-  msgid = msgid.split('\u0004');
-  if (msgid.length > 1) {
-    msgctxt = msgid.shift();
-    translation.msgctxt = msgctxt;
-  } else {
-    msgctxt = '';
-  }
-  msgid = msgid.join('\u0004');
-
-  const parts = msgid.split('\u0000');
-  msgid = parts.shift();
-
-  translation.msgid = msgid;
-
-  if ((msgidPlural = parts.join('\u0000'))) {
-    translation.msgid_plural = msgidPlural;
-  }
-
-  msgstr = msgstr.split('\u0000');
-  translation.msgstr = [].concat(msgstr || []);
-
-  if (!this._table.translations[msgctxt]) {
-    this._table.translations[msgctxt] = {};
-  }
-
-  this._table.translations[msgctxt][msgid] = translation;
-};
-
-/**
- * Parses the MO object and returns translation table
- *
- * @return {Object} Translation table
- */
-Parser.prototype.parse = function () {
-  if (!this._checkMagick()) {
     return false;
   }
 
   /**
+   * Read the original strings and translations from the input MO file. Use the
+   * first translation string in the file as the header.
+   */
+  _loadTranslationTable () {
+    let offsetOriginals = this._offsetOriginals;
+    let offsetTranslations = this._offsetTranslations;
+    let position;
+    let length;
+    let msgid;
+    let msgstr;
+
+    for (let i = 0; i < this._total; i++) {
+      // msgid string
+      length = this._fileContents[this._readFunc](offsetOriginals);
+      offsetOriginals += 4;
+      position = this._fileContents[this._readFunc](offsetOriginals);
+      offsetOriginals += 4;
+      msgid = this._fileContents.slice(position, position + length);
+
+      // matching msgstr
+      length = this._fileContents[this._readFunc](offsetTranslations);
+      offsetTranslations += 4;
+      position = this._fileContents[this._readFunc](offsetTranslations);
+      offsetTranslations += 4;
+      msgstr = this._fileContents.slice(position, position + length);
+
+      if (!i && !msgid.toString()) {
+        this._handleCharset(msgstr);
+      }
+
+      msgid = encoding.convert(msgid, 'utf-8', this._charset).toString('utf8');
+      msgstr = encoding
+        .convert(msgstr, 'utf-8', this._charset)
+        .toString('utf8');
+
+      this._addString(msgid, msgstr);
+    }
+
+    // dump the file contents object
+    this._fileContents = null;
+  }
+
+  /**
+   * Detects charset for MO strings from the header
+   *
+   * @param {Buffer} headers Header value
+   */
+  _handleCharset (headers) {
+    const headersStr = headers.toString();
+    let match;
+
+    if ((match = headersStr.match(/[; ]charset\s*=\s*([\w-]+)/i))) {
+      this._charset = this._table.charset = formatCharset(
+        match[1],
+        this._charset
+      );
+    }
+
+    headers = encoding
+      .convert(headers, 'utf-8', this._charset)
+      .toString('utf8');
+
+    this._table.headers = parseHeader(headers);
+  }
+
+  /**
+   * Adds a translation to the translation object
+   *
+   * @param {String} msgid Original string
+   * @params {String} msgstr Translation for the original string
+   */
+  _addString (msgid, msgstr) {
+    const translation = {};
+    let msgctxt;
+    let msgidPlural;
+
+    msgid = msgid.split('\u0004');
+    if (msgid.length > 1) {
+      msgctxt = msgid.shift();
+      translation.msgctxt = msgctxt;
+    } else {
+      msgctxt = '';
+    }
+    msgid = msgid.join('\u0004');
+
+    const parts = msgid.split('\u0000');
+    msgid = parts.shift();
+
+    translation.msgid = msgid;
+
+    if ((msgidPlural = parts.join('\u0000'))) {
+      translation.msgid_plural = msgidPlural;
+    }
+
+    msgstr = msgstr.split('\u0000');
+    translation.msgstr = [].concat(msgstr || []);
+
+    if (!this._table.translations[msgctxt]) {
+      this._table.translations[msgctxt] = {};
+    }
+
+    this._table.translations[msgctxt][msgid] = translation;
+  }
+
+  /**
+   * Parses the MO object and returns translation table
+   *
+   * @return {Object} Translation table
+   */
+  parse () {
+    if (!this._checkMagick()) {
+      return false;
+    }
+
+    /**
      * GetText revision nr, usually 0
      */
-  this._revision = this._fileContents[this._readFunc](4);
+    this._revision = this._fileContents[this._readFunc](4);
 
-  /**
+    /**
      * Total count of translated strings
      */
-  this._total = this._fileContents[this._readFunc](8);
+    this._total = this._fileContents[this._readFunc](8);
 
-  /**
+    /**
      * Offset position for original strings table
      */
-  this._offsetOriginals = this._fileContents[this._readFunc](12);
+    this._offsetOriginals = this._fileContents[this._readFunc](12);
 
-  /**
+    /**
      * Offset position for translation strings table
      */
-  this._offsetTranslations = this._fileContents[this._readFunc](16);
+    this._offsetTranslations = this._fileContents[this._readFunc](16);
 
-  // Load translations into this._translationTable
-  this._loadTranslationTable();
+    // Load translations into this._translationTable
+    this._loadTranslationTable();
 
-  return this._table;
-};
+    return this._table;
+  }
+}

--- a/lib/pocompiler.js
+++ b/lib/pocompiler.js
@@ -1,6 +1,12 @@
 import { Buffer } from 'node:buffer';
 import encoding from 'encoding';
-import { HEADERS, foldLine, compareMsgid, formatCharset, generateHeader } from './shared.js';
+import {
+  HEADERS,
+  foldLine,
+  compareMsgid,
+  formatCharset,
+  generateHeader
+} from './shared.js';
 import contentType from 'content-type';
 
 /**
@@ -14,276 +20,296 @@ export default function (table, options) {
   const compiler = new Compiler(table, options);
 
   return compiler.compile();
-};
-
-/**
- * Creates a PO compiler object.
- *
- * @constructor
- * @param {Object} table Translation table to be compiled
- */
-function Compiler (table = {}, options = {}) {
-  this._table = table;
-  this._options = options;
-
-  this._table.translations = this._table.translations || {};
-
-  let { headers = {} } = this._table;
-
-  headers = Object.keys(headers).reduce((result, key) => {
-    const lowerKey = key.toLowerCase();
-
-    if (HEADERS.has(lowerKey)) {
-      result[HEADERS.get(lowerKey)] = headers[key];
-    } else {
-      result[key] = headers[key];
-    }
-
-    return result;
-  }, {});
-
-  this._table.headers = headers;
-
-  if (!('foldLength' in this._options)) {
-    this._options.foldLength = 76;
-  }
-
-  if (!('escapeCharacters' in this._options)) {
-    this._options.escapeCharacters = true;
-  }
-
-  if (!('sort' in this._options)) {
-    this._options.sort = false;
-  }
-
-  if (!('eol' in this._options)) {
-    this._options.eol = '\n';
-  }
-
-  this._translations = [];
-
-  this._handleCharset();
 }
 
 /**
- * Converts a comments object to a comment string. The comment object is
- * in the form of {translator:'', reference: '', extracted: '', flag: '', previous:''}
- *
- * @param {Object} comments A comments object
- * @return {String} A comment string for the PO file
+ * Creates a PO compiler object.
  */
-Compiler.prototype._drawComments = function (comments) {
-  const lines = [];
-  const types = [{
-    key: 'translator',
-    prefix: '# '
-  }, {
-    key: 'reference',
-    prefix: '#: '
-  }, {
-    key: 'extracted',
-    prefix: '#. '
-  }, {
-    key: 'flag',
-    prefix: '#, '
-  }, {
-    key: 'previous',
-    prefix: '#| '
-  }];
+class Compiler {
+  constructor (table = {}, options = {}) {
+    this._table = table;
+    this._options = options;
 
-  types.forEach(type => {
-    if (!comments[type.key]) {
-      return;
-    }
+    this._table.translations = this._table.translations || {};
 
-    comments[type.key].split(/\r?\n|\r/).forEach(line => {
-      lines.push(`${type.prefix}${line}`);
-    });
-  });
+    let { headers = {} } = this._table;
 
-  return lines.join(this._options.eol);
-};
+    headers = Object.keys(headers).reduce((result, key) => {
+      const lowerKey = key.toLowerCase();
 
-/**
- * Builds a PO string for a single translation object
- *
- * @param {Object} block Translation object
- * @param {Object} [override] Properties of this object will override `block` properties
- * @param {boolean} [obsolete] Block is obsolete and must be commented out
- * @return {String} Translation string for a single object
- */
-Compiler.prototype._drawBlock = function (block, override = {}, obsolete = false) {
-  const response = [];
-  const msgctxt = override.msgctxt || block.msgctxt;
-  const msgid = override.msgid || block.msgid;
-  const msgidPlural = override.msgid_plural || block.msgid_plural;
-  const msgstr = [].concat(override.msgstr || block.msgstr);
-  let comments = override.comments || block.comments;
-
-  // add comments
-  if (comments && (comments = this._drawComments(comments))) {
-    response.push(comments);
-  }
-
-  if (msgctxt) {
-    response.push(this._addPOString('msgctxt', msgctxt, obsolete));
-  }
-
-  response.push(this._addPOString('msgid', msgid || '', obsolete));
-
-  if (msgidPlural) {
-    response.push(this._addPOString('msgid_plural', msgidPlural, obsolete));
-
-    msgstr.forEach((msgstr, i) => {
-      response.push(this._addPOString(`msgstr[${i}]`, msgstr || '', obsolete));
-    });
-  } else {
-    response.push(this._addPOString('msgstr', msgstr[0] || '', obsolete));
-  }
-
-  return response.join(this._options.eol);
-};
-
-/**
- * Escapes and joins a key and a value for the PO string
- *
- * @param {String} key Key name
- * @param {String} value Key value
- * @param {boolean} [obsolete] PO string is obsolete and must be commented out
- * @return {String} Joined and escaped key-value pair
- */
-Compiler.prototype._addPOString = function (key = '', value = '', obsolete = false) {
-  key = key.toString();
-  if (obsolete) {
-    key = '#~ ' + key;
-  }
-
-  let { foldLength, eol, escapeCharacters } = this._options;
-
-  // escape newlines and quotes
-  if (escapeCharacters) {
-    value = value.toString()
-      .replace(/\\/g, '\\\\')
-      .replace(/"/g, '\\"')
-      .replace(/\t/g, '\\t')
-      .replace(/\r/g, '\\r');
-  }
-
-  value = value.replace(/\n/g, '\\n'); // need to escape new line characters regardless
-
-  let lines = [value];
-
-  if (obsolete) {
-    eol = eol + '#~ ';
-  }
-
-  if (foldLength > 0) {
-    lines = foldLine(value, foldLength);
-  } else {
-    // split only on new lines
-    if (escapeCharacters) {
-      lines = value.split(/\\n/g);
-      for (let i = 0; i < lines.length - 1; i++) {
-        lines[i] = `${lines[i]}\\n`;
+      if (HEADERS.has(lowerKey)) {
+        result[HEADERS.get(lowerKey)] = headers[key];
+      } else {
+        result[key] = headers[key];
       }
-      if (lines.length && lines[lines.length - 1] === '') {
-        lines.splice(-1, 1);
+
+      return result;
+    }, {});
+
+    this._table.headers = headers;
+
+    if (!('foldLength' in this._options)) {
+      this._options.foldLength = 76;
+    }
+
+    if (!('escapeCharacters' in this._options)) {
+      this._options.escapeCharacters = true;
+    }
+
+    if (!('sort' in this._options)) {
+      this._options.sort = false;
+    }
+
+    if (!('eol' in this._options)) {
+      this._options.eol = '\n';
+    }
+
+    this._translations = [];
+
+    this._handleCharset();
+  }
+
+  /**
+   * Converts a comments object to a comment string. The comment object is
+   * in the form of {translator:'', reference: '', extracted: '', flag: '', previous:''}
+   *
+   * @param {Object} comments A comments object
+   * @return {String} A comment string for the PO file
+   */
+  _drawComments (comments) {
+    const lines = [];
+    const types = [
+      {
+        key: 'translator',
+        prefix: '# '
+      },
+      {
+        key: 'reference',
+        prefix: '#: '
+      },
+      {
+        key: 'extracted',
+        prefix: '#. '
+      },
+      {
+        key: 'flag',
+        prefix: '#, '
+      },
+      {
+        key: 'previous',
+        prefix: '#| '
       }
-    }
-  }
+    ];
 
-  if (lines.length < 2) {
-    return `${key} "${lines.shift() || ''}"`;
-  }
-
-  return `${key} ""${eol}"${lines.join(`"${eol}"`)}"`;
-};
-
-/**
- * Handles header values, replaces or adds (if needed) a charset property
- */
-Compiler.prototype._handleCharset = function () {
-  const ct = contentType.parse(this._table.headers['Content-Type'] || 'text/plain');
-
-  const charset = formatCharset(this._table.charset || ct.parameters.charset || 'utf-8');
-
-  // clean up content-type charset independently using fallback if missing
-  if (ct.parameters.charset) {
-    ct.parameters.charset = formatCharset(ct.parameters.charset);
-  }
-
-  this._table.charset = charset;
-  this._table.headers['Content-Type'] = contentType.format(ct);
-};
-
-/**
- * Flatten and sort translations object
- *
- * @param {Object} section Object to be prepared (translations or obsolete)
- * @returns {Array} Prepared array
- */
-Compiler.prototype._prepareSection = function (section) {
-  let response = [];
-
-  Object.keys(section).forEach(msgctxt => {
-    if (typeof section[msgctxt] !== 'object') {
-      return;
-    }
-
-    Object.keys(section[msgctxt]).forEach(msgid => {
-      if (typeof section[msgctxt][msgid] !== 'object') {
+    types.forEach((type) => {
+      if (!comments[type.key]) {
         return;
       }
 
-      if (msgctxt === '' && msgid === '') {
-        return;
-      }
-
-      response.push(section[msgctxt][msgid]);
+      comments[type.key].split(/\r?\n|\r/).forEach((line) => {
+        lines.push(`${type.prefix}${line}`);
+      });
     });
-  });
 
-  const { sort } = this._options;
+    return lines.join(this._options.eol);
+  }
 
-  if (sort !== false) {
-    if (typeof sort === 'function') {
-      response = response.sort(sort);
+  /**
+   * Builds a PO string for a single translation object
+   *
+   * @param {Object} block Translation object
+   * @param {Object} [override] Properties of this object will override `block` properties
+   * @param {boolean} [obsolete] Block is obsolete and must be commented out
+   * @return {String} Translation string for a single object
+   */
+  _drawBlock (block, override = {}, obsolete = false) {
+    const response = [];
+    const msgctxt = override.msgctxt || block.msgctxt;
+    const msgid = override.msgid || block.msgid;
+    const msgidPlural = override.msgid_plural || block.msgid_plural;
+    const msgstr = [].concat(override.msgstr || block.msgstr);
+    let comments = override.comments || block.comments;
+
+    // add comments
+    if (comments && (comments = this._drawComments(comments))) {
+      response.push(comments);
+    }
+
+    if (msgctxt) {
+      response.push(this._addPOString('msgctxt', msgctxt, obsolete));
+    }
+
+    response.push(this._addPOString('msgid', msgid || '', obsolete));
+
+    if (msgidPlural) {
+      response.push(this._addPOString('msgid_plural', msgidPlural, obsolete));
+
+      msgstr.forEach((msgstr, i) => {
+        response.push(
+          this._addPOString(`msgstr[${i}]`, msgstr || '', obsolete)
+        );
+      });
     } else {
-      response = response.sort(compareMsgid);
+      response.push(this._addPOString('msgstr', msgstr[0] || '', obsolete));
     }
+
+    return response.join(this._options.eol);
   }
 
-  return response;
-};
-
-/**
- * Compiles translation object into a PO object
- *
- * @return {Buffer} Compiled PO object
- */
-Compiler.prototype.compile = function () {
-  const headerBlock = (this._table.translations[''] && this._table.translations['']['']) || {};
-  let response = [];
-
-  const translations = this._prepareSection(this._table.translations);
-  response = translations.map(r => this._drawBlock(r));
-
-  if (typeof this._table.obsolete === 'object') {
-    const obsolete = this._prepareSection(this._table.obsolete);
-    if (obsolete.length) {
-      response = response.concat(obsolete.map(r => this._drawBlock(r, {}, true)));
+  /**
+   * Escapes and joins a key and a value for the PO string
+   *
+   * @param {String} key Key name
+   * @param {String} value Key value
+   * @param {boolean} [obsolete] PO string is obsolete and must be commented out
+   * @return {String} Joined and escaped key-value pair
+   */
+  _addPOString (key = '', value = '', obsolete = false) {
+    key = key.toString();
+    if (obsolete) {
+      key = '#~ ' + key;
     }
+
+    let { foldLength, eol, escapeCharacters } = this._options;
+
+    // escape newlines and quotes
+    if (escapeCharacters) {
+      value = value
+        .toString()
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\t/g, '\\t')
+        .replace(/\r/g, '\\r');
+    }
+
+    value = value.replace(/\n/g, '\\n'); // need to escape new line characters regardless
+
+    let lines = [value];
+
+    if (obsolete) {
+      eol = eol + '#~ ';
+    }
+
+    if (foldLength > 0) {
+      lines = foldLine(value, foldLength);
+    } else {
+      // split only on new lines
+      if (escapeCharacters) {
+        lines = value.split(/\\n/g);
+        for (let i = 0; i < lines.length - 1; i++) {
+          lines[i] = `${lines[i]}\\n`;
+        }
+        if (lines.length && lines[lines.length - 1] === '') {
+          lines.splice(-1, 1);
+        }
+      }
+    }
+
+    if (lines.length < 2) {
+      return `${key} "${lines.shift() || ''}"`;
+    }
+
+    return `${key} ""${eol}"${lines.join(`"${eol}"`)}"`;
   }
 
-  const { eol } = this._options;
+  /**
+   * Handles header values, replaces or adds (if needed) a charset property
+   */
+  _handleCharset () {
+    const ct = contentType.parse(
+      this._table.headers['Content-Type'] || 'text/plain'
+    );
 
-  response.unshift(this._drawBlock(headerBlock, {
-    msgstr: generateHeader(this._table.headers)
-  }));
+    const charset = formatCharset(
+      this._table.charset || ct.parameters.charset || 'utf-8'
+    );
 
-  if (this._table.charset === 'utf-8' || this._table.charset === 'ascii') {
-    return Buffer.from(response.join(eol + eol) + eol, 'utf-8');
+    // clean up content-type charset independently using fallback if missing
+    if (ct.parameters.charset) {
+      ct.parameters.charset = formatCharset(ct.parameters.charset);
+    }
+
+    this._table.charset = charset;
+    this._table.headers['Content-Type'] = contentType.format(ct);
   }
 
-  return encoding.convert(response.join(eol + eol) + eol, this._table.charset);
-};
+  /**
+   * Flatten and sort translations object
+   *
+   * @param {Object} section Object to be prepared (translations or obsolete)
+   * @returns {Array} Prepared array
+   */
+  _prepareSection (section) {
+    let response = [];
+
+    Object.keys(section).forEach((msgctxt) => {
+      if (typeof section[msgctxt] !== 'object') {
+        return;
+      }
+
+      Object.keys(section[msgctxt]).forEach((msgid) => {
+        if (typeof section[msgctxt][msgid] !== 'object') {
+          return;
+        }
+
+        if (msgctxt === '' && msgid === '') {
+          return;
+        }
+
+        response.push(section[msgctxt][msgid]);
+      });
+    });
+
+    const { sort } = this._options;
+
+    if (sort !== false) {
+      if (typeof sort === 'function') {
+        response = response.sort(sort);
+      } else {
+        response = response.sort(compareMsgid);
+      }
+    }
+
+    return response;
+  }
+
+  /**
+   * Compiles translation object into a PO object
+   *
+   * @return {Buffer} Compiled PO object
+   */
+  compile () {
+    const headerBlock =
+      (this._table.translations[''] && this._table.translations['']['']) || {};
+    let response = [];
+
+    const translations = this._prepareSection(this._table.translations);
+    response = translations.map((r) => this._drawBlock(r));
+
+    if (typeof this._table.obsolete === 'object') {
+      const obsolete = this._prepareSection(this._table.obsolete);
+      if (obsolete.length) {
+        response = response.concat(
+          obsolete.map((r) => this._drawBlock(r, {}, true))
+        );
+      }
+    }
+
+    const { eol } = this._options;
+
+    response.unshift(
+      this._drawBlock(headerBlock, {
+        msgstr: generateHeader(this._table.headers)
+      })
+    );
+
+    if (this._table.charset === 'utf-8' || this._table.charset === 'ascii') {
+      return Buffer.from(response.join(eol + eol) + eol, 'utf-8');
+    }
+
+    return encoding.convert(
+      response.join(eol + eol) + eol,
+      this._table.charset
+    );
+  }
+}

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -1,7 +1,10 @@
 import encoding from 'encoding';
-import { formatCharset, parseNPluralFromHeadersSafely, parseHeader } from './shared.js';
+import {
+  formatCharset,
+  parseNPluralFromHeadersSafely,
+  parseHeader
+} from './shared.js';
 import { Transform } from 'readable-stream';
-import util from 'util';
 
 /**
  * Parses a PO object into translation table
@@ -14,7 +17,7 @@ export function parse (input, options = {}) {
   const parser = new Parser(input, options);
 
   return parser.parse();
-};
+}
 
 /**
  * Parses a PO stream, emits translation table in object mode
@@ -25,612 +28,633 @@ export function parse (input, options = {}) {
  */
 export function stream (options = {}, transformOptions = {}) {
   return new PoParserTransform(options, transformOptions);
-};
+}
 
 /**
  * Creates a PO parser object. If PO object is a string,
  * UTF-8 will be used as the charset
  *
  * @typedef {{ defaultCharset?: string, validation?: boolean }} Options
- * @constructor
- * @param {string | Buffer} fileContents PO object
- * @param {Options} options Options with defaultCharset and validation
  */
-function Parser (fileContents, { defaultCharset = 'iso-8859-1', validation = false }) {
-  this._validation = validation;
-  this._charset = defaultCharset;
+class Parser {
+  constructor (
+    fileContents,
+    { defaultCharset = 'iso-8859-1', validation = false }
+  ) {
+    this._validation = validation;
+    this._charset = defaultCharset;
 
-  this._lex = [];
-  this._escaped = false;
-  this._node = {};
-  this._state = this.states.none;
-  this._lineNumber = 1;
+    this._lex = [];
+    this._escaped = false;
+    this._node = {};
+    this._state = this.states.none;
+    this._lineNumber = 1;
 
-  if (typeof fileContents === 'string') {
-    this._charset = 'utf-8';
-    this._fileContents = fileContents;
-  } else {
-    this._fileContents = this._handleCharset(fileContents);
-  }
-}
-
-/**
- * Parses the PO object and returns translation table
- *
- * @return {Object} Translation table
- */
-Parser.prototype.parse = function () {
-  this._lexer(this._fileContents);
-
-  return this._finalize(this._lex);
-};
-
-/**
- * Detects charset for PO strings from the header
- *
- * @param {Buffer} headers Header value
- */
-Parser.prototype._handleCharset = function (buf = '') {
-  const str = buf.toString();
-  let pos;
-  let headers = '';
-  let match;
-
-  if ((pos = str.search(/^\s*msgid/im)) >= 0) {
-    pos = pos + str.substr(pos + 5).search(/^\s*(msgid|msgctxt)/im);
-    headers = str.substr(0, pos >= 0 ? pos + 5 : str.length);
+    if (typeof fileContents === 'string') {
+      this._charset = 'utf-8';
+      this._fileContents = fileContents;
+    } else {
+      this._fileContents = this._handleCharset(fileContents);
+    }
   }
 
-  if ((match = headers.match(/[; ]charset\s*=\s*([\w-]+)(?:[\s;]|\\n)*"\s*$/mi))) {
-    this._charset = formatCharset(match[1], this._charset);
+  /**
+   * Parses the PO object and returns translation table
+   *
+   * @return {Object} Translation table
+   */
+  parse () {
+    this._lexer(this._fileContents);
+
+    return this._finalize(this._lex);
   }
 
-  if (this._charset === 'utf-8') {
-    return str;
-  }
+  /**
+   * Detects charset for PO strings from the header
+   *
+   * @param {Buffer} headers Header value
+   */
+  _handleCharset (buf = '') {
+    const str = buf.toString();
+    let pos;
+    let headers = '';
+    let match;
 
-  return this._toString(buf);
-};
-
-Parser.prototype._toString = function (buf) {
-  return encoding.convert(buf, 'utf-8', this._charset).toString('utf-8');
-};
-
-/**
- * State constants for parsing FSM
- */
-Parser.prototype.states = {
-  none: 0x01,
-  comments: 0x02,
-  key: 0x03,
-  string: 0x04,
-  obsolete: 0x05
-};
-
-/**
- * Value types for lexer
- */
-Parser.prototype.types = {
-  comments: 0x01,
-  key: 0x02,
-  string: 0x03,
-  obsolete: 0x04
-};
-
-/**
- * String matches for lexer
- */
-Parser.prototype.symbols = {
-  quotes: /["']/,
-  comments: /#/,
-  whitespace: /\s/,
-  key: /[\w\-[\]]/,
-  keyNames: /^(?:msgctxt|msgid(?:_plural)?|msgstr(?:\[\d+])?)$/
-};
-
-/**
- * Token parser. Parsed state can be found from this._lex
- *
- * @param {String} chunk String
- */
-Parser.prototype._lexer = function (chunk) {
-  let chr;
-
-  for (let i = 0, len = chunk.length; i < len; i++) {
-    chr = chunk.charAt(i);
-
-    if (chr === '\n') {
-      this._lineNumber += 1;
+    if ((pos = str.search(/^\s*msgid/im)) >= 0) {
+      pos = pos + str.substr(pos + 5).search(/^\s*(msgid|msgctxt)/im);
+      headers = str.substr(0, pos >= 0 ? pos + 5 : str.length);
     }
 
-    switch (this._state) {
-      case this.states.none:
-      case this.states.obsolete:
-        if (chr.match(this.symbols.quotes)) {
-          this._node = {
-            type: this.types.string,
-            value: '',
-            quote: chr
-          };
-          this._lex.push(this._node);
-          this._state = this.states.string;
-        } else if (chr.match(this.symbols.comments)) {
-          this._node = {
-            type: this.types.comments,
-            value: ''
-          };
-          this._lex.push(this._node);
-          this._state = this.states.comments;
-        } else if (!chr.match(this.symbols.whitespace)) {
-          this._node = {
-            type: this.types.key,
-            value: chr
-          };
-          if (this._state === this.states.obsolete) {
-            this._node.obsolete = true;
+    if (
+      (match = headers.match(/[; ]charset\s*=\s*([\w-]+)(?:[\s;]|\\n)*"\s*$/im))
+    ) {
+      this._charset = formatCharset(match[1], this._charset);
+    }
+
+    if (this._charset === 'utf-8') {
+      return str;
+    }
+
+    return this._toString(buf);
+  }
+
+  _toString (buf) {
+    return encoding.convert(buf, 'utf-8', this._charset).toString('utf-8');
+  }
+
+  /**
+   * State constants for parsing FSM
+   */
+  states = {
+    none: 0x01,
+    comments: 0x02,
+    key: 0x03,
+    string: 0x04,
+    obsolete: 0x05
+  };
+
+  /**
+   * Value types for lexer
+   */
+  types = {
+    comments: 0x01,
+    key: 0x02,
+    string: 0x03,
+    obsolete: 0x04
+  };
+
+  /**
+   * String matches for lexer
+   */
+  symbols = {
+    quotes: /["']/,
+    comments: /#/,
+    whitespace: /\s/,
+    key: /[\w\-[\]]/,
+    keyNames: /^(?:msgctxt|msgid(?:_plural)?|msgstr(?:\[\d+])?)$/
+  };
+
+  /**
+   * Token parser. Parsed state can be found from this._lex
+   *
+   * @param {String} chunk String
+   */
+  _lexer (chunk) {
+    let chr;
+
+    for (let i = 0, len = chunk.length; i < len; i++) {
+      chr = chunk.charAt(i);
+
+      if (chr === '\n') {
+        this._lineNumber += 1;
+      }
+
+      switch (this._state) {
+        case this.states.none:
+        case this.states.obsolete:
+          if (chr.match(this.symbols.quotes)) {
+            this._node = {
+              type: this.types.string,
+              value: '',
+              quote: chr
+            };
+            this._lex.push(this._node);
+            this._state = this.states.string;
+          } else if (chr.match(this.symbols.comments)) {
+            this._node = {
+              type: this.types.comments,
+              value: ''
+            };
+            this._lex.push(this._node);
+            this._state = this.states.comments;
+          } else if (!chr.match(this.symbols.whitespace)) {
+            this._node = {
+              type: this.types.key,
+              value: chr
+            };
+            if (this._state === this.states.obsolete) {
+              this._node.obsolete = true;
+            }
+            this._lex.push(this._node);
+            this._state = this.states.key;
           }
-          this._lex.push(this._node);
-          this._state = this.states.key;
-        }
-        break;
-      case this.states.comments:
-        if (chr === '\n') {
-          this._state = this.states.none;
-        } else if (chr === '~' && this._node.value === '') {
-          this._node.value += chr;
-          this._state = this.states.obsolete;
-        } else if (chr !== '\r') {
-          this._node.value += chr;
-        }
-        break;
-      case this.states.string:
-        if (this._escaped) {
-          switch (chr) {
-            case 't':
-              this._node.value += '\t';
-              break;
-            case 'n':
-              this._node.value += '\n';
-              break;
-            case 'r':
-              this._node.value += '\r';
-              break;
-            default:
-              this._node.value += chr;
-          }
-          this._escaped = false;
-        } else {
-          if (chr === this._node.quote) {
+          break;
+        case this.states.comments:
+          if (chr === '\n') {
             this._state = this.states.none;
-          } else if (chr === '\\') {
-            this._escaped = true;
-            break;
+          } else if (chr === '~' && this._node.value === '') {
+            this._node.value += chr;
+            this._state = this.states.obsolete;
+          } else if (chr !== '\r') {
+            this._node.value += chr;
+          }
+          break;
+        case this.states.string:
+          if (this._escaped) {
+            switch (chr) {
+              case 't':
+                this._node.value += '\t';
+                break;
+              case 'n':
+                this._node.value += '\n';
+                break;
+              case 'r':
+                this._node.value += '\r';
+                break;
+              default:
+                this._node.value += chr;
+            }
+            this._escaped = false;
+          } else {
+            if (chr === this._node.quote) {
+              this._state = this.states.none;
+            } else if (chr === '\\') {
+              this._escaped = true;
+              break;
+            } else {
+              this._node.value += chr;
+            }
+            this._escaped = false;
+          }
+          break;
+        case this.states.key:
+          if (!chr.match(this.symbols.key)) {
+            if (!this._node.value.match(this.symbols.keyNames)) {
+              const err = new SyntaxError(
+                `Error parsing PO data: Invalid key name "${this._node.value}" at line ${this._lineNumber}. This can be caused by an unescaped quote character in a msgid or msgstr value.`
+              );
+
+              err.lineNumber = this._lineNumber;
+
+              throw err;
+            }
+            this._state = this.states.none;
+            i--;
           } else {
             this._node.value += chr;
           }
-          this._escaped = false;
+          break;
+      }
+    }
+  }
+
+  /**
+   * Join multi line strings
+   *
+   * @param {Object} tokens Parsed tokens
+   * @return {Object} Parsed tokens, with multi line strings joined into one
+   */
+  _joinStringValues (tokens) {
+    const response = [];
+    let lastNode;
+
+    for (let i = 0, len = tokens.length; i < len; i++) {
+      if (
+        lastNode &&
+        tokens[i].type === this.types.string &&
+        lastNode.type === this.types.string
+      ) {
+        lastNode.value += tokens[i].value;
+      } else if (
+        lastNode &&
+        tokens[i].type === this.types.comments &&
+        lastNode.type === this.types.comments
+      ) {
+        lastNode.value += '\n' + tokens[i].value;
+      } else {
+        response.push(tokens[i]);
+        lastNode = tokens[i];
+      }
+    }
+
+    return response;
+  }
+
+  /**
+   * Parse comments into separate comment blocks
+   *
+   * @param {Object} tokens Parsed tokens
+   */
+  _parseComments (tokens) {
+    // parse comments
+    tokens.forEach((node) => {
+      if (!node || node.type !== this.types.comments) {
+        return;
+      }
+
+      const comment = {
+        translator: [],
+        extracted: [],
+        reference: [],
+        flag: [],
+        previous: []
+      };
+
+      const lines = (node.value || '').split(/\n/);
+
+      lines.forEach((line) => {
+        switch (line.charAt(0) || '') {
+          case ':':
+            comment.reference.push(line.substr(1).trim());
+            break;
+          case '.':
+            comment.extracted.push(line.substr(1).replace(/^\s+/, ''));
+            break;
+          case ',':
+            comment.flag.push(line.substr(1).replace(/^\s+/, ''));
+            break;
+          case '|':
+            comment.previous.push(line.substr(1).replace(/^\s+/, ''));
+            break;
+          case '~':
+            break;
+          default:
+            comment.translator.push(line.replace(/^\s+/, ''));
         }
-        break;
-      case this.states.key:
-        if (!chr.match(this.symbols.key)) {
-          if (!this._node.value.match(this.symbols.keyNames)) {
-            const err = new SyntaxError(`Error parsing PO data: Invalid key name "${this._node.value}" at line ${this._lineNumber}. This can be caused by an unescaped quote character in a msgid or msgstr value.`);
+      });
 
-            err.lineNumber = this._lineNumber;
+      node.value = {};
 
-            throw err;
+      Object.keys(comment).forEach((key) => {
+        if (comment[key] && comment[key].length) {
+          node.value[key] = comment[key].join('\n');
+        }
+      });
+    });
+  }
+
+  /**
+   * Join gettext keys with values
+   *
+   * @param {Object} tokens Parsed tokens
+   * @return {Object} Tokens
+   */
+  _handleKeys (tokens) {
+    const response = [];
+    let lastNode;
+
+    for (let i = 0, len = tokens.length; i < len; i++) {
+      if (tokens[i].type === this.types.key) {
+        lastNode = {
+          key: tokens[i].value
+        };
+        if (tokens[i].obsolete) {
+          lastNode.obsolete = true;
+        }
+        if (i && tokens[i - 1].type === this.types.comments) {
+          lastNode.comments = tokens[i - 1].value;
+        }
+        lastNode.value = '';
+        response.push(lastNode);
+      } else if (tokens[i].type === this.types.string && lastNode) {
+        lastNode.value += tokens[i].value;
+      }
+    }
+
+    return response;
+  }
+
+  /**
+   * Separate different values into individual translation objects
+   *
+   * @param {Object} tokens Parsed tokens
+   * @return {Object} Tokens
+   */
+  _handleValues (tokens) {
+    const response = [];
+    let lastNode;
+    let curContext;
+    let curComments;
+
+    for (let i = 0, len = tokens.length; i < len; i++) {
+      if (tokens[i].key.toLowerCase() === 'msgctxt') {
+        curContext = tokens[i].value;
+        curComments = tokens[i].comments;
+      } else if (tokens[i].key.toLowerCase() === 'msgid') {
+        lastNode = {
+          msgid: tokens[i].value
+        };
+        if (tokens[i].obsolete) {
+          lastNode.obsolete = true;
+        }
+
+        if (curContext) {
+          lastNode.msgctxt = curContext;
+        }
+
+        if (curComments) {
+          lastNode.comments = curComments;
+        }
+
+        if (tokens[i].comments && !lastNode.comments) {
+          lastNode.comments = tokens[i].comments;
+        }
+
+        curContext = false;
+        curComments = false;
+        response.push(lastNode);
+      } else if (tokens[i].key.toLowerCase() === 'msgid_plural') {
+        if (lastNode) {
+          if (this._validation && 'msgid_plural' in lastNode) {
+            throw new SyntaxError(
+              `Multiple msgid_plural error: entry "${lastNode.msgid}" in "${lastNode.msgctxt || ''}" context has multiple msgid_plural declarations.`
+            );
           }
-          this._state = this.states.none;
-          i--;
-        } else {
-          this._node.value += chr;
+
+          lastNode.msgid_plural = tokens[i].value;
         }
-        break;
-    }
-  }
-};
 
-/**
- * Join multi line strings
- *
- * @param {Object} tokens Parsed tokens
- * @return {Object} Parsed tokens, with multi line strings joined into one
- */
-Parser.prototype._joinStringValues = function (tokens) {
-  const response = [];
-  let lastNode;
+        if (tokens[i].comments && !lastNode.comments) {
+          lastNode.comments = tokens[i].comments;
+        }
 
-  for (let i = 0, len = tokens.length; i < len; i++) {
-    if (lastNode && tokens[i].type === this.types.string && lastNode.type === this.types.string) {
-      lastNode.value += tokens[i].value;
-    } else if (lastNode && tokens[i].type === this.types.comments && lastNode.type === this.types.comments) {
-      lastNode.value += '\n' + tokens[i].value;
-    } else {
-      response.push(tokens[i]);
-      lastNode = tokens[i];
+        curContext = false;
+        curComments = false;
+      } else if (tokens[i].key.substr(0, 6).toLowerCase() === 'msgstr') {
+        if (lastNode) {
+          lastNode.msgstr = (lastNode.msgstr || []).concat(tokens[i].value);
+        }
+
+        if (tokens[i].comments && !lastNode.comments) {
+          lastNode.comments = tokens[i].comments;
+        }
+
+        curContext = false;
+        curComments = false;
+      }
     }
+
+    return response;
   }
 
-  return response;
-};
-
-/**
- * Parse comments into separate comment blocks
- *
- * @param {Object} tokens Parsed tokens
- */
-Parser.prototype._parseComments = function (tokens) {
-  // parse comments
-  tokens.forEach(node => {
-    if (!node || node.type !== this.types.comments) {
+  /**
+   * Validate token
+   *
+   * @param {Object} token Parsed token
+   * @param {Object} translations Translation table
+   * @param {string} msgctxt Message entry context
+   * @param {number} nplurals Number of epected plural forms
+   * @throws Will throw an error if token validation fails
+   */
+  _validateToken (
+    {
+      msgid = '',
+      msgid_plural: msgidPlural = '', // eslint-disable-line camelcase
+      msgstr = []
+    },
+    translations,
+    msgctxt,
+    nplurals
+  ) {
+    if (!this._validation) {
       return;
     }
 
-    const comment = {
-      translator: [],
-      extracted: [],
-      reference: [],
-      flag: [],
-      previous: []
-    };
-
-    const lines = (node.value || '').split(/\n/);
-
-    lines.forEach(line => {
-      switch (line.charAt(0) || '') {
-        case ':':
-          comment.reference.push(line.substr(1).trim());
-          break;
-        case '.':
-          comment.extracted.push(line.substr(1).replace(/^\s+/, ''));
-          break;
-        case ',':
-          comment.flag.push(line.substr(1).replace(/^\s+/, ''));
-          break;
-        case '|':
-          comment.previous.push(line.substr(1).replace(/^\s+/, ''));
-          break;
-        case '~':
-          break;
-        default:
-          comment.translator.push(line.replace(/^\s+/, ''));
-      }
-    });
-
-    node.value = {};
-
-    Object.keys(comment).forEach(key => {
-      if (comment[key] && comment[key].length) {
-        node.value[key] = comment[key].join('\n');
-      }
-    });
-  });
-};
-
-/**
- * Join gettext keys with values
- *
- * @param {Object} tokens Parsed tokens
- * @return {Object} Tokens
- */
-Parser.prototype._handleKeys = function (tokens) {
-  const response = [];
-  let lastNode;
-
-  for (let i = 0, len = tokens.length; i < len; i++) {
-    if (tokens[i].type === this.types.key) {
-      lastNode = {
-        key: tokens[i].value
-      };
-      if (tokens[i].obsolete) {
-        lastNode.obsolete = true;
-      }
-      if (i && tokens[i - 1].type === this.types.comments) {
-        lastNode.comments = tokens[i - 1].value;
-      }
-      lastNode.value = '';
-      response.push(lastNode);
-    } else if (tokens[i].type === this.types.string && lastNode) {
-      lastNode.value += tokens[i].value;
+    if (msgid in translations[msgctxt]) {
+      throw new SyntaxError(
+        `Duplicate msgid error: entry "${msgid}" in "${msgctxt}" context has already been declared.`
+      );
+      // eslint-disable-next-line camelcase
+    } else if (msgidPlural && msgstr.length !== nplurals) {
+      // eslint-disable-next-line camelcase
+      throw new RangeError(
+        `Plural forms range error: Expected to find ${nplurals} forms but got ${msgstr.length} for entry "${msgidPlural}" in "${msgctxt}" context.`
+      );
+      // eslint-disable-next-line camelcase
+    } else if (!msgidPlural && msgstr.length !== 1) {
+      throw new RangeError(
+        `Translation string range error: Extected 1 msgstr definitions associated with "${msgid}" in "${msgctxt}" context, found ${msgstr.length}.`
+      );
     }
   }
 
-  return response;
-};
+  /**
+   * Compose a translation table from tokens object
+   *
+   * @param {Object} tokens Parsed tokens
+   * @return {Object} Translation table
+   */
+  _normalize (tokens) {
+    const table = {
+      charset: this._charset,
+      headers: undefined,
+      translations: {}
+    };
+    let nplurals = 1;
+    let msgctxt;
 
-/**
- * Separate different values into individual translation objects
- *
- * @param {Object} tokens Parsed tokens
- * @return {Object} Tokens
- */
-Parser.prototype._handleValues = function (tokens) {
-  const response = [];
-  let lastNode;
-  let curContext;
-  let curComments;
+    for (let i = 0, len = tokens.length; i < len; i++) {
+      msgctxt = tokens[i].msgctxt || '';
 
-  for (let i = 0, len = tokens.length; i < len; i++) {
-    if (tokens[i].key.toLowerCase() === 'msgctxt') {
-      curContext = tokens[i].value;
-      curComments = tokens[i].comments;
-    } else if (tokens[i].key.toLowerCase() === 'msgid') {
-      lastNode = {
-        msgid: tokens[i].value
-      };
       if (tokens[i].obsolete) {
-        lastNode.obsolete = true;
-      }
-
-      if (curContext) {
-        lastNode.msgctxt = curContext;
-      }
-
-      if (curComments) {
-        lastNode.comments = curComments;
-      }
-
-      if (tokens[i].comments && !lastNode.comments) {
-        lastNode.comments = tokens[i].comments;
-      }
-
-      curContext = false;
-      curComments = false;
-      response.push(lastNode);
-    } else if (tokens[i].key.toLowerCase() === 'msgid_plural') {
-      if (lastNode) {
-        if (this._validation && 'msgid_plural' in lastNode) {
-          throw new SyntaxError(`Multiple msgid_plural error: entry "${lastNode.msgid}" in "${lastNode.msgctxt || ''}" context has multiple msgid_plural declarations.`);
+        if (!table.obsolete) {
+          table.obsolete = {};
         }
 
-        lastNode.msgid_plural = tokens[i].value;
+        if (!table.obsolete[msgctxt]) {
+          table.obsolete[msgctxt] = {};
+        }
+
+        delete tokens[i].obsolete;
+
+        table.obsolete[msgctxt][tokens[i].msgid] = tokens[i];
+
+        continue;
       }
 
-      if (tokens[i].comments && !lastNode.comments) {
-        lastNode.comments = tokens[i].comments;
+      if (!table.translations[msgctxt]) {
+        table.translations[msgctxt] = {};
       }
 
-      curContext = false;
-      curComments = false;
-    } else if (tokens[i].key.substr(0, 6).toLowerCase() === 'msgstr') {
-      if (lastNode) {
-        lastNode.msgstr = (lastNode.msgstr || []).concat(tokens[i].value);
+      if (!table.headers && !msgctxt && !tokens[i].msgid) {
+        table.headers = parseHeader(tokens[i].msgstr[0]);
+        nplurals = parseNPluralFromHeadersSafely(table.headers, nplurals);
       }
 
-      if (tokens[i].comments && !lastNode.comments) {
-        lastNode.comments = tokens[i].comments;
-      }
+      this._validateToken(tokens[i], table.translations, msgctxt, nplurals);
 
-      curContext = false;
-      curComments = false;
-    }
-  }
-
-  return response;
-};
-
-/**
- * Validate token
- *
- * @param {Object} token Parsed token
- * @param {Object} translations Translation table
- * @param {string} msgctxt Message entry context
- * @param {number} nplurals Number of epected plural forms
- * @throws Will throw an error if token validation fails
- */
-Parser.prototype._validateToken = function (
-  {
-    msgid = '',
-    msgid_plural = '', // eslint-disable-line camelcase
-    msgstr = []
-  },
-  translations,
-  msgctxt,
-  nplurals
-) {
-  if (!this._validation) {
-    return;
-  }
-
-  if (msgid in translations[msgctxt]) {
-    throw new SyntaxError(`Duplicate msgid error: entry "${msgid}" in "${msgctxt}" context has already been declared.`);
-    // eslint-disable-next-line camelcase
-  } else if (msgid_plural && msgstr.length !== nplurals) {
-    // eslint-disable-next-line camelcase
-    throw new RangeError(`Plural forms range error: Expected to find ${nplurals} forms but got ${msgstr.length} for entry "${msgid_plural}" in "${msgctxt}" context.`);
-    // eslint-disable-next-line camelcase
-  } else if (!msgid_plural && msgstr.length !== 1) {
-    throw new RangeError(`Translation string range error: Extected 1 msgstr definitions associated with "${msgid}" in "${msgctxt}" context, found ${msgstr.length}.`);
-  }
-};
-
-/**
- * Compose a translation table from tokens object
- *
- * @param {Object} tokens Parsed tokens
- * @return {Object} Translation table
- */
-Parser.prototype._normalize = function (tokens) {
-  const table = {
-    charset: this._charset,
-    headers: undefined,
-    translations: {}
-  };
-  let nplurals = 1;
-  let msgctxt;
-
-  for (let i = 0, len = tokens.length; i < len; i++) {
-    msgctxt = tokens[i].msgctxt || '';
-
-    if (tokens[i].obsolete) {
-      if (!table.obsolete) {
-        table.obsolete = {};
-      }
-
-      if (!table.obsolete[msgctxt]) {
-        table.obsolete[msgctxt] = {};
-      }
-
-      delete tokens[i].obsolete;
-
-      table.obsolete[msgctxt][tokens[i].msgid] = tokens[i];
-
-      continue;
+      table.translations[msgctxt][tokens[i].msgid] = tokens[i];
     }
 
-    if (!table.translations[msgctxt]) {
-      table.translations[msgctxt] = {};
-    }
-
-    if (!table.headers && !msgctxt && !tokens[i].msgid) {
-      table.headers = parseHeader(tokens[i].msgstr[0]);
-      nplurals = parseNPluralFromHeadersSafely(table.headers, nplurals);
-    }
-
-    this._validateToken(tokens[i], table.translations, msgctxt, nplurals);
-
-    table.translations[msgctxt][tokens[i].msgid] = tokens[i];
+    return table;
   }
 
-  return table;
-};
+  /**
+   * Converts parsed tokens to a translation table
+   *
+   * @param {Object} tokens Parsed tokens
+   * @returns {Object} Translation table
+   */
+  _finalize (tokens) {
+    let data = this._joinStringValues(tokens);
 
-/**
- * Converts parsed tokens to a translation table
- *
- * @param {Object} tokens Parsed tokens
- * @returns {Object} Translation table
- */
-Parser.prototype._finalize = function (tokens) {
-  let data = this._joinStringValues(tokens);
+    this._parseComments(data);
 
-  this._parseComments(data);
+    data = this._handleKeys(data);
+    data = this._handleValues(data);
 
-  data = this._handleKeys(data);
-  data = this._handleValues(data);
-
-  return this._normalize(data);
-};
+    return this._normalize(data);
+  }
+}
 
 /**
  * Creates a transform stream for parsing PO input
  *
  * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
- * @constructor
- * @param {Options} options Optional options with defaultCharset and validation
- * @param {import('readable-stream').TransformOptions} transformOptions Optional stream options
  */
-function PoParserTransform (options, transformOptions) {
-  this.options = options;
-  this._parser = false;
-  this._tokens = {};
+class PoParserTransform extends Transform {
+  constructor (options, transformOptions) {
+    super(transformOptions);
 
-  this._cache = [];
-  this._cacheSize = 0;
+    this.options = options;
+    this._parser = false;
+    this._tokens = {};
 
-  this.initialTreshold = transformOptions.initialTreshold || 2 * 1024;
+    this._cache = [];
+    this._cacheSize = 0;
 
-  Transform.call(this, transformOptions);
-  this._writableState.objectMode = false;
-  this._readableState.objectMode = true;
-}
-util.inherits(PoParserTransform, Transform);
+    this.initialTreshold = transformOptions.initialTreshold || 2 * 1024;
 
-/**
- * Processes a chunk of the input stream
- */
-PoParserTransform.prototype._transform = function (chunk, encoding, done) {
-  let i;
-  let len = 0;
-
-  if (!chunk || !chunk.length) {
-    return done();
+    this._writableState.objectMode = false;
+    this._readableState.objectMode = true;
   }
 
-  if (!this._parser) {
-    this._cache.push(chunk);
-    this._cacheSize += chunk.length;
+  /**
+   * Processes a chunk of the input stream
+   */
+  _transform (chunk, encoding, done) {
+    let i;
+    let len = 0;
 
-    // wait until the first 1kb before parsing headers for charset
-    if (this._cacheSize < this.initialTreshold) {
-      return setImmediate(done);
+    if (!chunk || !chunk.length) {
+      return done();
+    }
+
+    if (!this._parser) {
+      this._cache.push(chunk);
+      this._cacheSize += chunk.length;
+
+      // wait until the first 1kb before parsing headers for charset
+      if (this._cacheSize < this.initialTreshold) {
+        return setImmediate(done);
+      } else if (this._cacheSize) {
+        chunk = Buffer.concat(this._cache, this._cacheSize);
+        this._cacheSize = 0;
+        this._cache = [];
+      }
+
+      this._parser = new Parser(chunk, this.options);
     } else if (this._cacheSize) {
+      // this only happens if we had an uncompleted 8bit sequence from the last iteration
+      this._cache.push(chunk);
+      this._cacheSize += chunk.length;
       chunk = Buffer.concat(this._cache, this._cacheSize);
       this._cacheSize = 0;
       this._cache = [];
     }
 
-    this._parser = new Parser(chunk, this.options);
-  } else if (this._cacheSize) {
-    // this only happens if we had an uncompleted 8bit sequence from the last iteration
-    this._cache.push(chunk);
-    this._cacheSize += chunk.length;
-    chunk = Buffer.concat(this._cache, this._cacheSize);
-    this._cacheSize = 0;
-    this._cache = [];
-  }
-
-  // cache 8bit bytes from the end of the chunk
-  // helps if the chunk ends in the middle of an utf-8 sequence
-  for (i = chunk.length - 1; i >= 0; i--) {
-    if (chunk[i] >= 0x80) {
-      len++;
-      continue;
+    // cache 8bit bytes from the end of the chunk
+    // helps if the chunk ends in the middle of an utf-8 sequence
+    for (i = chunk.length - 1; i >= 0; i--) {
+      if (chunk[i] >= 0x80) {
+        len++;
+        continue;
+      }
+      break;
     }
-    break;
-  }
-  // it seems we found some 8bit bytes from the end of the string, so let's cache these
-  if (len) {
-    this._cache = [chunk.slice(chunk.length - len)];
-    this._cacheSize = this._cache[0].length;
-    chunk = chunk.slice(0, chunk.length - len);
-  }
-
-  // chunk might be empty if it only continued of 8bit bytes and these were all cached
-  if (chunk.length) {
-    try {
-      this._parser._lexer(this._parser._toString(chunk));
-    } catch (error) {
-      setImmediate(() => {
-        done(error);
-      });
-
-      return;
+    // it seems we found some 8bit bytes from the end of the string, so let's cache these
+    if (len) {
+      this._cache = [chunk.slice(chunk.length - len)];
+      this._cacheSize = this._cache[0].length;
+      chunk = chunk.slice(0, chunk.length - len);
     }
-  }
 
-  setImmediate(done);
-};
+    // chunk might be empty if it only continued of 8bit bytes and these were all cached
+    if (chunk.length) {
+      try {
+        this._parser._lexer(this._parser._toString(chunk));
+      } catch (error) {
+        setImmediate(() => {
+          done(error);
+        });
 
-/**
- * Once all input has been processed emit the parsed translation table as an object
- */
-PoParserTransform.prototype._flush = function (done) {
-  let chunk;
-
-  if (this._cacheSize) {
-    chunk = Buffer.concat(this._cache, this._cacheSize);
-  }
-
-  if (!this._parser && chunk) {
-    this._parser = new Parser(chunk, this.options);
-  }
-
-  if (chunk) {
-    try {
-      this._parser._lexer(this._parser._toString(chunk));
-    } catch (error) {
-      setImmediate(() => {
-        done(error);
-      });
-
-      return;
+        return;
+      }
     }
+
+    setImmediate(done);
   }
 
-  if (this._parser) {
-    this.push(this._parser._finalize(this._parser._lex));
-  }
+  /**
+   * Once all input has been processed emit the parsed translation table as an object
+   */
+  _flush (done) {
+    let chunk;
 
-  setImmediate(done);
-};
+    if (this._cacheSize) {
+      chunk = Buffer.concat(this._cache, this._cacheSize);
+    }
+
+    if (!this._parser && chunk) {
+      this._parser = new Parser(chunk, this.options);
+    }
+
+    if (chunk) {
+      try {
+        this._parser._lexer(this._parser._toString(chunk));
+      } catch (error) {
+        setImmediate(() => {
+          done(error);
+        });
+
+        return;
+      }
+    }
+
+    if (this._parser) {
+      this.push(this._parser._finalize(this._parser._lex));
+    }
+
+    setImmediate(done);
+  }
+}


### PR DESCRIPTION
This PR updates the package to use ES6 classes instead of prototype hacks.

ES6 classes are supported by atleast Node 6, and all the newer fancy features like static initialisation fields are supported by Node 16.

This PR also fixes an issue where this package wouldn't load in browsers due to it depending on node's `util` package.