### PR TITLE
stop using `readable-stream`

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -1,6 +1,6 @@
 import encoding from 'encoding';
 import { formatCharset, parseNPluralFromHeadersSafely, parseHeader } from './shared.js';
-import { Transform } from 'readable-stream';
+import { Transform } from 'node:stream';
 import util from 'util';
 
 /**
@@ -21,7 +21,7 @@ export function parse (input, options = {}) {
  *
  * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
  * @param {Options} [options] Optional options with defaultCharset and validation
- * @param {import('readable-stream').TransformOptions} [transformOptions] Optional stream options
+ * @param {import('node:stream').TransformOptions} [transformOptions] Optional stream options
  */
 export function stream (options = {}, transformOptions = {}) {
   return new PoParserTransform(options, transformOptions);
@@ -515,7 +515,7 @@ Parser.prototype._finalize = function (tokens) {
  * @typedef {{ defaultCharset: strubg, validation: boolean }} Options
  * @constructor
  * @param {Options} options Optional options with defaultCharset and validation
- * @param {import('readable-stream').TransformOptions} transformOptions Optional stream options
+ * @param {import('node:stream').TransformOptions} transformOptions Optional stream options
  */
 function PoParserTransform (options, transformOptions) {
   this.options = options;

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "content-type": "^1.0.5",
-    "encoding": "^0.1.13",
-    "readable-stream": "^4.5.2"
+    "encoding": "^0.1.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
`readable-stream` is only needed to support node < 18
as documented in `package.json` we expect node >= 18
