### PR TITLE
enforce `node:` import protocol

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,11 +2,13 @@ import js from '@eslint/js';
 import globals from 'globals';
 import { defineConfig } from 'eslint/config';
 import stylistic from '@stylistic/eslint-plugin';
+import importPlugin from 'eslint-plugin-import';
 
 export default defineConfig([
   {
     files: ['**/*.{js,mjs,cjs}'],
     plugins: {
+      import: importPlugin,
       js,
       '@stylistic': stylistic
     },
@@ -17,6 +19,9 @@ export default defineConfig([
         ...globals.node,
         ...globals.mocha
       }
+    },
+    rules: {
+      'import/enforce-node-protocol-usage': ['error', 'always']
     }
   }
 ]);

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -1,7 +1,7 @@
 import encoding from 'encoding';
 import { formatCharset, parseNPluralFromHeadersSafely, parseHeader } from './shared.js';
 import { Transform } from 'node:stream';
-import util from 'util';
+import util from 'node:util';
 
 /**
  * Parses a PO object into translation table

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@eslint/js": "^9.39.2",
     "@stylistic/eslint-plugin": "^5.6.1",
     "eslint": "^9.39.2",
+    "eslint-plugin-import": "^2.32.0",
     "globals": "^16.5.0"
   },
   "keywords": [

--- a/test/mo-compiler-test.js
+++ b/test/mo-compiler-test.js
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { promisify } from 'util';
-import path from 'path';
+import { promisify } from 'node:util';
+import path from 'node:path';
 import { mo } from '../index.js';
-import { readFile as fsReadFile } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFile as fsReadFile } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/test/mo-parser-test.js
+++ b/test/mo-parser-test.js
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { promisify } from 'util';
-import path from 'path';
+import { promisify } from 'node:util';
+import path from 'node:path';
 import { mo } from '../index.js';
-import { readFile as fsReadFile } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFile as fsReadFile } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/test/po-compiler-test.js
+++ b/test/po-compiler-test.js
@@ -1,11 +1,11 @@
-import { EOL } from 'os';
-import { promisify } from 'util';
-import path from 'path';
-import { readFile as fsReadFile } from 'fs';
+import { EOL } from 'node:os';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { readFile as fsReadFile } from 'node:fs';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { po } from '../index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/test/po-obsolete-test.js
+++ b/test/po-obsolete-test.js
@@ -1,11 +1,11 @@
-import { EOL } from 'os';
+import { EOL } from 'node:os';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { promisify } from 'util';
-import path from 'path';
-import fs from 'fs';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import fs from 'node:fs';
 import * as gettextParser from '../index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { promisify } from 'util';
-import path from 'path';
-import fs from 'fs';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import fs from 'node:fs';
 import * as gettextParser from '../index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/test/shared.js
+++ b/test/shared.js
@@ -2,11 +2,11 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { promisify } from 'util';
-import path from 'path';
+import { promisify } from 'node:util';
+import path from 'node:path';
 import { formatCharset, parseHeader, generateHeader, foldLine, parseNPluralFromHeadersSafely } from '../lib/shared.js';
-import { readFile as fsReadFile } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFile as fsReadFile } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
- **use `node:` import protocol consistently**
- **enforce `import/enforce-node-protocol-usage` eslint rule**
