### PR TITLE
Support parsing and compiling previous translations in obsolete entries

### DIFF
--- a/lib/pocompiler.js
+++ b/lib/pocompiler.js
@@ -70,9 +70,10 @@ function Compiler (table = {}, options = {}) {
  * in the form of {translator:'', reference: '', extracted: '', flag: '', previous:''}
  *
  * @param {Object} comments A comments object
+ * @param {boolean} [obsolete] This comments object is for an obsolete block
  * @return {String} A comment string for the PO file
  */
-Compiler.prototype._drawComments = function (comments) {
+Compiler.prototype._drawComments = function (comments, obsolete = false) {
   const lines = [];
   const types = [{
     key: 'translator',
@@ -88,7 +89,7 @@ Compiler.prototype._drawComments = function (comments) {
     prefix: '#, '
   }, {
     key: 'previous',
-    prefix: '#| '
+    prefix: obsolete ? '#~| ' : '#| '
   }];
 
   types.forEach(type => {
@@ -121,7 +122,7 @@ Compiler.prototype._drawBlock = function (block, override = {}, obsolete = false
   let comments = override.comments || block.comments;
 
   // add comments
-  if (comments && (comments = this._drawComments(comments))) {
+  if (comments && (comments = this._drawComments(comments, obsolete))) {
     response.push(comments);
   }
 

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -161,6 +161,13 @@ Parser.prototype._lexer = function (chunk) {
           };
           this._lex.push(this._node);
           this._state = this.states.comments;
+        } else if (chr === '|') {
+          this._node = {
+            type: this.types.comments,
+            value: chr
+          };
+          this._lex.push(this._node);
+          this._state = this.states.comments;
         } else if (!chr.match(this.symbols.whitespace)) {
           this._node = {
             type: this.types.key,

--- a/test/fixtures/obsolete.json
+++ b/test/fixtures/obsolete.json
@@ -38,6 +38,17 @@
                     "One",
                     "Two"
                 ]
+            },
+            "Obsolete message with previous translation": {
+                "msgid": "Obsolete message with previous translation",
+                "comments": {
+                    "flag": "fuzzy",
+                    "previous": "msgid \"Obsolete message with previous tr\"",
+                    "translator": "Obsolete message with previous"
+                },
+                "msgstr": [
+                    "Translation"
+                ]
             }
         },
         "Obsolete context": {

--- a/test/fixtures/obsolete.po
+++ b/test/fixtures/obsolete.po
@@ -16,6 +16,12 @@ msgstr "Test msgstr"
 #~ msgstr[0] "One"
 #~ msgstr[1] "Two"
 
+# Obsolete message with previous
+#, fuzzy
+#~| msgid "Obsolete message with previous tr"
+#~ msgid "Obsolete message with previous translation"
+#~ msgstr "Translation"
+
 # Obsolete message with context
 #, fuzzy
 #~ msgctxt "Obsolete context"


### PR DESCRIPTION
Fixes #111. After investigating that I thought I might try my hand at fixing it.

A `#~|` is a previous (un)translated string (like `#|`) in an obsolete entry, and is emitted when a string is translated, updated with `msgmerge --previous` (thus creating a `#|` previous translation), then made obsolete (removed) before a translator could act on it. `msgmerge` generates it as seen in [this msgmerge test case](https://github.com/autotools-mirror/gettext/blob/91348b3d6ec5f5556c91bb6f31610dd3baaeb943/gettext-tools/tests/msgmerge-10#L197).

The approach I've taken here for lexing [seems to be what GNU Gettext does as well](https://github.com/autotools-mirror/gettext/blob/91348b3d6ec5f5556c91bb6f31610dd3baaeb943/gettext-tools/src/read-po-lex.c#L1114). (While the GNU Gettext comment says it "does not make sense semantically, and is implemented here for completeness only", it does actually make sense to exist as explained above, and [does actually exist in the wild in at least 200k files](https://github.com/search?q=path%3A%2Fpo%24%2F%20%22%23~%7C%22&type=code).)